### PR TITLE
Convert public functions, with improved methods; change default width pairs to use 'constant'

### DIFF
--- a/swn/core.py
+++ b/swn/core.py
@@ -1037,76 +1037,91 @@ class SurfaceWaterNetwork(object):
         else:
             raise ValueError('unknown use for upstream_area')
         if not isinstance(a, (float, int)):
-            a = self._segment_series(a, 'a')
+            a = self.segments_series(a, 'a')
         if not isinstance(b, (float, int)):
-            b = self._segment_series(a, 'b')
+            b = self.segments_series(a, 'b')
         self.segments['width'] = a + upstream_area_km2 ** b
 
-    def _segment_series(self, value, name=None):
-        """Return a pandas.Series along the segment index.
+    def segments_series(self, value, name=None):
+        """Generate a Series along the segments index.
 
         Parameters
         ----------
-        value : float or pandas.Series
-            If value is a float, it is repated for each segment, otherwise
-            a Series is used, with a check to ensure it is the same index.
-        name : str, optional
-            Name used for series, if provided. Default is None.
+        value : scalar, list, dict or pandas.Series
+            If value is a Series, it is checked to ensure it is has the same
+            index as :py:attr:`SurfaceWaterNetwork.segments`. Otherwise value
+            as a scalar, list or dict is cast as a Series with
+            ``segments.index``.
+        name : str or None (default)
+            Name used for series, if provided.
 
         Returns
         -------
         pandas.Series
 
+        Examples
+        --------
+        >>> import swn
+        >>> from swn.spatial import wkt_to_geoseries
+        >>> lines = wkt_to_geoseries([
+        ...    "LINESTRING (60 100, 60  80)",
+        ...    "LINESTRING (40 130, 60 100)",
+        ...    "LINESTRING (70 130, 60 100)"])
+        >>> n = swn.SurfaceWaterNetwork.from_lines(lines)
+        >>> n.segments_series(1.2)
+        0    1.2
+        1    1.2
+        2    1.2
+        dtype: float64
+        >>> n.segments_series([3, 2, 1], "codes")
+        0    3
+        1    2
+        2    1
+        Name: codes, dtype: int64
         """
         segments_index = self.segments.index
-        if not isinstance(value, pd.Series):
+        if np.isscalar(value):
             value = pd.Series(value, index=segments_index)
-        elif (len(value.index) != len(segments_index) or
+        elif isinstance(value, pd.Series):
+            pass
+        elif isinstance(value, (list, dict)):
+            value = pd.Series(value)
+        else:
+            raise ValueError(
+                "expected value to be scalar, list, dict or Series")
+        if (len(value.index) != len(segments_index) or
                 not (value.index == segments_index).all()):
             raise ValueError('index is different than for segments')
         if name is not None:
             value.name = name
         return value
 
-    def _outlet_series(self, value):
-        """Return a pandas.Series along the outlet index.
-
-        Parameters
-        ----------
-        value : float or pandas.Series
-            If value is a float, it is repated for each outlet, otherwise
-            a Series is used, with a check to ensure it is the same index.
-
-        Returns
-        -------
-        pandas.Series
-
-        """
-        outlets_index = self.outlets
-        if not isinstance(value, pd.Series):
-            value = pd.Series(value, index=outlets_index)
-        elif (len(value.index) != len(outlets_index) or
-                not (value.index == outlets_index).all()):
-            raise ValueError('index is different than for outlets')
-        return value
-
-    def _pair_segment_values(self, value1, outlet_value=None, name=None):
-        """Return a pair of values that connect the segments.
+    def pair_segments_df(self, value, outlet_value=None, name=None):
+        """Generate a DataFrame of paired values of connected segments.
 
         The first value applies to the top of each segment, and the bottom
-        value is determined from the top of the value it connects to. Special
-        consideration is applied to outlet segments.
+        value is determined from the top of the value it connects to. This
+        allows for continious values to be assigned to segments, where the
+        value at the top of a segment is the same as the bottom of the
+        segments that connect to it. Special consideration is applied to
+        outlet segments.
 
         Parameters
         ----------
-        value1 : float or pandas.Series
-            Value to assign to the top of each segment.
-        outlet_value : None, float or pandas.Series
+        value : scalar, list, dict or pandas.Series
+            Value to assign to the upstream or top end of each segment.
+            If value is a Series, it is checked to ensure it is has the same
+            index as :py:attr:`SurfaceWaterNetwork.segments`. Otherwise value
+            as a scalar, list or dict is cast as a Series with
+            ``segments.index``.
+        outlet_value : None (default), scalar, list, dict or pandas.Series
             If None (default), the value used for the bottom of outlet segments
-            is assumed to be the same as the top. Otherwise, a Series
-            for each outlet can be specified.
-        name : str, optional
-            Base name used for each series pair, if provided. Default is None.
+            is assumed to be the same as the top (value). If outlet_value is a
+            Series, it is checked to ensure it is has the same index as
+            :py:attr:`SurfaceWaterNetwork.outlets`. Otherwise outlet_value as a
+            scalar, list or dict is cast as a Series with ``outlets.index``.
+        name : str, default None
+            Base name used for the column names, if provided.
 
         Returns
         -------
@@ -1114,10 +1129,29 @@ class SurfaceWaterNetwork(object):
             Resulting DataFrame has two columns for top (1) and bottom (2) of
             each segment.
 
+        Examples
+        --------
+        >>> import swn
+        >>> from swn.spatial import wkt_to_geoseries
+        >>> lines = wkt_to_geoseries([
+        ...    "LINESTRING (60 100, 60  80)",
+        ...    "LINESTRING (40 130, 60 100)",
+        ...    "LINESTRING (70 130, 60 100)"])
+        >>> n = swn.SurfaceWaterNetwork.from_lines(lines)
+        >>> n.pair_segments_df([3, 4, 5])
+           1  2
+        0  3  3
+        1  4  3
+        2  5  3
+        >>> n.pair_segments_df([4.0, 3.0, 5.0], {0: 6.0}, name="width")
+           width1  width2
+        0     4.0     6.0
+        1     3.0     4.0
+        2     5.0     4.0
         """
-        value1 = self._segment_series(value1, name=name)
-        df = pd.concat([value1, value1], axis=1)
-        if value1.name is not None:
+        value = self.segments_series(value, name=name)
+        df = pd.concat([value, value], axis=1)
+        if value.name is not None:
             df.columns = df.columns.str.cat(['1', '2'])
         else:
             df.columns += 1
@@ -1125,7 +1159,21 @@ class SurfaceWaterNetwork(object):
         c1, c2 = df.columns
         df.loc[to_segnums.index, c2] = df.loc[to_segnums, c1].values
         if outlet_value is not None:
-            outlet_value = self._outlet_series(outlet_value)
+            # generate outlet series
+            outlets_index = self.outlets
+            if np.isscalar(outlet_value):
+                outlet_value = pd.Series(outlet_value, index=outlets_index)
+            elif isinstance(outlet_value, pd.Series):
+                pass
+            elif isinstance(outlet_value, (list, dict)):
+                outlet_value = pd.Series(outlet_value)
+            else:
+                raise ValueError(
+                    "expected outlet_value to be scalar, list, dict or Series")
+            if (len(outlet_value.index) != len(outlets_index) or
+                    not (outlet_value.index == outlets_index).all()):
+                raise ValueError(
+                    "outlet_value.index is different than for outlets")
             df.loc[outlet_value.index, c2] = outlet_value
         return df
 
@@ -1140,7 +1188,7 @@ class SurfaceWaterNetwork(object):
             Default 1./1000 (or 0.001).
 
         """
-        min_slope = self._segment_series(min_slope)
+        min_slope = self.segments_series(min_slope)
         if (min_slope <= 0.0).any():
             raise ValueError('min_slope must be greater than zero')
         elif not self.has_z:
@@ -1261,7 +1309,7 @@ class SurfaceWaterNetwork(object):
         None
 
         """
-        condition = self._segment_series(condition, 'condition').astype(bool)
+        condition = self.segments_series(condition, 'condition').astype(bool)
         if condition.any():
             self.logger.debug(
                 'selecting %d segnum(s) based on a condition',

--- a/swn/modflow/_base.py
+++ b/swn/modflow/_base.py
@@ -244,7 +244,7 @@ class SwnModflowBase(object):
         # Break up source segments according to the model grid definition
         obj.logger.debug("evaluating reach data on model grid")
         grid_sindex = get_sindex(grid_cells)
-        reach_include = swn._segment_series(reach_include_fraction) * cell_size
+        reach_include = swn.segments_series(reach_include_fraction) * cell_size
         # Make an empty DataFrame for reaches
         obj.reaches = pd.DataFrame(columns=["geometry"])
         obj.reaches.insert(1, column="i", value=pd.Series(dtype=int))
@@ -696,7 +696,7 @@ class SwnModflowBase(object):
         """
         if not isinstance(name, str):
             raise ValueError("'name' must be a str type")
-        segdat = self._swn._pair_segment_values(value, value_out, name)
+        segdat = self._swn.pair_segments_df(value, value_out, name)
         for item in segdat.itertuples():
             sel = self.reaches["segnum"] == item[0]
             if item[1] == item[2]:

--- a/swn/modflow/_legacy.py
+++ b/swn/modflow/_legacy.py
@@ -222,7 +222,7 @@ class MfSfrNetwork(object):
             grid_df, geometry=[Polygon(r) for r in cell_verts], crs=crs)
         obj.logger.debug('evaluating reach data on model grid')
         grid_sindex = get_sindex(grid_cells)
-        reach_include = swn._segment_series(reach_include_fraction) * cell_size
+        reach_include = swn.segments_series(reach_include_fraction) * cell_size
         # Make an empty DataFrame for reaches
         obj.reaches = pd.DataFrame(columns=['geometry'])
         obj.reaches.insert(1, column='row', value=pd.Series(dtype=int))
@@ -518,7 +518,7 @@ class MfSfrNetwork(object):
                 obj.reaches, geometry='geometry', crs=crs)
 
         # Assign segment data
-        obj.segments['min_slope'] = swn._segment_series(min_slope)
+        obj.segments['min_slope'] = swn.segments_series(min_slope)
         if (obj.segments['min_slope'] < 0.0).any():
             raise ValueError('min_slope must be greater than zero')
         # Column names common to segments and segment_data
@@ -532,13 +532,13 @@ class MfSfrNetwork(object):
                 del obj.segments[col]
         # Combine pairs of series for each segment
         more_segment_columns = pd.concat([
-            swn._pair_segment_values(hyd_cond1, hyd_cond_out, 'hcond'),
-            swn._pair_segment_values(thickness1, thickness_out, 'thickm'),
-            swn._pair_segment_values(width1, width_out, name='width')
+            swn.pair_segments_df(hyd_cond1, hyd_cond_out, 'hcond'),
+            swn.pair_segments_df(thickness1, thickness_out, 'thickm'),
+            swn.pair_segments_df(width1, width_out, name='width')
         ], axis=1, copy=False)
         for name, series in more_segment_columns.iteritems():
             obj.segments[name] = series
-        obj.segments['roughch'] = swn._segment_series(roughch)
+        obj.segments['roughch'] = swn.segments_series(roughch)
         # Mark segments that are not used
         obj.segments['in_model'] = True
         outside_model = \

--- a/swn/modflow/_legacy.py
+++ b/swn/modflow/_legacy.py
@@ -532,9 +532,10 @@ class MfSfrNetwork(object):
                 del obj.segments[col]
         # Combine pairs of series for each segment
         more_segment_columns = pd.concat([
-            swn.pair_segments_df(hyd_cond1, hyd_cond_out, 'hcond'),
-            swn.pair_segments_df(thickness1, thickness_out, 'thickm'),
-            swn.pair_segments_df(width1, width_out, name='width')
+            swn.pair_segments_frame(hyd_cond1, hyd_cond_out, 'hcond'),
+            swn.pair_segments_frame(thickness1, thickness_out, 'thickm'),
+            swn.pair_segments_frame(width1, width_out, name='width',
+                                    method="constant")
         ], axis=1, copy=False)
         for name, series in more_segment_columns.iteritems():
             obj.segments[name] = series

--- a/swn/modflow/_swnmf6.py
+++ b/swn/modflow/_swnmf6.py
@@ -523,8 +523,7 @@ class SwnMf6(SwnModflowBase):
             "segments", otherwise will use 10.
         width_out : None, float or pandas.Series, optional
             Similar to width1, but for the bottom of each segment outlet.
-            If None (default), the same width1 value for the top of the
-            outlet segment is used for the bottom.
+            If None (default), use a constant width1 value for segment.
         roughch : float or pandas.Series, optional
             Manning's roughness coefficient for the channel. If float, then
             this is a global value, otherwise it is per-segment with a Series.
@@ -548,7 +547,8 @@ class SwnMf6(SwnModflowBase):
                 action_args = (width1,)
             self.logger.info(
                 "default_packagedata: 'rwd' " + action, *action_args)
-        self.set_reach_data_from_segments("rwid", width1, width_out)
+        self.set_reach_data_from_segments(
+            "rwid", width1, width_out, method="constant")
 
         if "rgrd" not in self.reaches.columns:
             self.logger.info(

--- a/swn/modflow/_swnmodflow.py
+++ b/swn/modflow/_swnmodflow.py
@@ -574,13 +574,13 @@ class SwnModflow(SwnModflowBase):
         # Combine pairs of series for each segment
         swn = self._swn
         more_segment_columns = pd.concat([
-            swn._pair_segment_values(hyd_cond1, hyd_cond_out, "hcond"),
-            swn._pair_segment_values(thickness1, thickness_out, "thickm"),
-            swn._pair_segment_values(width1, width_out, name="width")
+            swn.pair_segments_df(hyd_cond1, hyd_cond_out, "hcond"),
+            swn.pair_segments_df(thickness1, thickness_out, "thickm"),
+            swn.pair_segments_df(width1, width_out, name="width")
         ], axis=1, copy=False)
         for name, series in more_segment_columns.iteritems():
             self.segments[name] = series
-        self.segments["roughch"] = swn._segment_series(roughch)
+        self.segments["roughch"] = swn.segments_series(roughch)
 
         # Interpolate segment properties to each reach
         self.set_reach_data_from_segments(

--- a/swn/modflow/_swnmodflow.py
+++ b/swn/modflow/_swnmodflow.py
@@ -528,8 +528,7 @@ class SwnModflow(SwnModflowBase):
             "width" from "segments", otherwise will use 10.
         width_out : None, float or pandas.Series, optional
             Similar to width1, but for the bottom of each segment outlet.
-            If None (default), the same width1 value for the top of the
-            outlet segment is used for the bottom.
+            If None (default), use a constant width1 value for segment.
         roughch : float or pandas.Series, optional
             Manning's roughness coefficient for the channel. If float, then
             this is a global value, otherwise it is per-segment with a Series.
@@ -574,9 +573,10 @@ class SwnModflow(SwnModflowBase):
         # Combine pairs of series for each segment
         swn = self._swn
         more_segment_columns = pd.concat([
-            swn.pair_segments_df(hyd_cond1, hyd_cond_out, "hcond"),
-            swn.pair_segments_df(thickness1, thickness_out, "thickm"),
-            swn.pair_segments_df(width1, width_out, name="width")
+            swn.pair_segments_frame(hyd_cond1, hyd_cond_out, "hcond"),
+            swn.pair_segments_frame(thickness1, thickness_out, "thickm"),
+            swn.pair_segments_frame(
+                width1, width_out, name="width", method="constant")
         ], axis=1, copy=False)
         for name, series in more_segment_columns.iteritems():
             self.segments[name] = series
@@ -588,7 +588,7 @@ class SwnModflow(SwnModflowBase):
         self.set_reach_data_from_segments(
             "strthick", thickness1, thickness_out)
         self.set_reach_data_from_segments(
-            "strhc1", hyd_cond1, hyd_cond_out, log10=True)
+            "strhc1", hyd_cond1, hyd_cond_out, log=True)
 
         # Get stream values from top of model
         self.set_reach_data_from_array("strtop", self.model.dis.top.array)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -699,178 +699,121 @@ def test_estimate_width():
         n2.estimate_width()
 
 
-def test_segment_series(valid_n):
+def test_segments_series(valid_n):
     n = valid_n
+    errmsg = "index is different than for segments"
     # from scalar
-    v = n._segment_series(8.0)
-    assert list(v.index) == [0, 1, 2]
-    assert list(v) == [8.0, 8.0, 8.0]
-    assert v.name is None
-    v = n._segment_series(8.0, name='eight')
-    assert list(v.index) == [0, 1, 2]
-    assert list(v) == [8.0, 8.0, 8.0]
-    assert v.name == 'eight'
-    v = n._segment_series('$VAL$')
-    assert list(v) == ['$VAL$', '$VAL$', '$VAL$']
+    pd.testing.assert_series_equal(
+        n.segments_series(8.0),
+        pd.Series([8.0] * 3))
+    pd.testing.assert_series_equal(
+        n.segments_series(8, name="eight"),
+        pd.Series([8, 8, 8], name="eight"))
+    pd.testing.assert_series_equal(
+        n.segments_series("$VAL$"),
+        pd.Series(["$VAL$"] * 3))
     # from list
-    v = n._segment_series([3, 4, 5])
-    assert list(v.index) == [0, 1, 2]
-    assert list(v) == [3, 4, 5]
-    assert v.name is None
-    v = n._segment_series([3, 4, 5], name='list')
-    assert list(v.index) == [0, 1, 2]
-    assert list(v) == [3, 4, 5]
-    assert v.name == 'list'
-    v = n._segment_series(['$VAL1$', '$VAL2$', '$VAL3$'])
-    assert list(v.index) == [0, 1, 2]
-    assert list(v) == ['$VAL1$', '$VAL2$', '$VAL3$']
-    assert v.name is None
+    pd.testing.assert_series_equal(
+        n.segments_series([3, 4, 5]),
+        pd.Series([3, 4, 5]))
+    pd.testing.assert_series_equal(
+        n.segments_series([3, 4, 5], name="list"),
+        pd.Series([3, 4, 5], name="list"))
+    pd.testing.assert_series_equal(
+        n.segments_series(["$VAL1$", "$VAL2$", "$VAL3$"]),
+        pd.Series(["$VAL1$", "$VAL2$", "$VAL3$"]))
+    with pytest.raises(ValueError, match=errmsg):
+        n.segments_series([8])
+    with pytest.raises(ValueError, match=errmsg):
+        n.segments_series([3, 4, 5, 6])
+    # from dict
+    pd.testing.assert_series_equal(
+        n.segments_series({0: 1.1, 1: 2.2, 2: 3.3}),
+        pd.Series([1.1, 2.2, 3.3]))
+    with pytest.raises(ValueError, match=errmsg):
+        n.segments_series({0: 1.1, 1: 2.2, 3: 3.3})
     # from Series
     s = pd.Series([2.0, 3.0, 4.0])
-    v = n._segment_series(s)
-    assert list(v.index) == [0, 1, 2]
-    assert list(v) == [2.0, 3.0, 4.0]
-    assert v.name is None
-    s.name = 'foo'
-    v = n._segment_series(s)
-    assert v.name == 'foo'
-    v = n._segment_series(s, name='bar')
-    assert v.name == 'bar'
+    pd.testing.assert_series_equal(n.segments_series(s), s)
+    s = pd.Series([2.0, 3.0, 4.0], name="foo")
+    pd.testing.assert_series_equal(n.segments_series(s), s)
     # now break it
     s.index += 1
-    with pytest.raises(ValueError,
-                       match='index is different than for segments'):
-        n._segment_series(s)
+    with pytest.raises(ValueError, match=errmsg):
+        n.segments_series(s)
+    # misc error
+    with pytest.raises(ValueError, match="expected value to be scalar, list,"):
+        n.segments_series(object())
 
 
-def test_outlet_series():
-    # make a network with outlet on index 2
-    n = swn.SurfaceWaterNetwork.from_lines(wkt_to_geoseries([
-        'LINESTRING Z (40 130 15, 60 100 14)',
-        'LINESTRING Z (70 130 15, 60 100 14)',
-        'LINESTRING Z (60 100 14, 60  80 12)',
-    ]))
-    # from scalar
-    v = n._outlet_series(8.0)
-    assert list(v.index) == [2]
-    assert list(v) == [8.0]
-    assert v.name is None
-    v = n._outlet_series('$VAL$')
-    assert list(v) == ['$VAL$']
-    # from list
-    v = n._outlet_series([8])
-    assert list(v.index) == [2]
-    assert list(v) == [8]
-    assert v.name is None
-    v = n._outlet_series(['$VAL_out$'])
-    assert list(v.index) == [2]
-    assert list(v) == ['$VAL_out$']
-    assert v.name is None
-    # from Series
-    s = pd.Series([5.0], index=[2])
-    v = n._outlet_series(s)
-    assert list(v.index) == [2]
-    assert list(v) == [5.0]
-    assert v.name is None
-    s.name = 'foo'
-    v = n._outlet_series(s)
-    assert v.name == 'foo'
-    # now break it
-    s.index -= 1
-    with pytest.raises(ValueError,
-                       match='index is different than for outlets'):
-        n._outlet_series(s)
-
-
-def test_pair_segment_values(valid_n):
+def test_pair_segments_df(valid_n):
     n = valid_n
+    errmsg_segments = "index is different than for segments"
+    errmsg_outlets = "outlet_value.index is different than for outlets"
     # from scalar
-    p = n._pair_segment_values(8.0)
-    assert list(p.columns) == [1, 2]
-    assert list(p.index) == [0, 1, 2]
-    expected = np.ones((3, 2)) * 8.0
-    np.testing.assert_equal(p, expected)
-    p = n._pair_segment_values(8.0, name='foo')
-    assert list(p.columns) == ['foo1', 'foo2']
-    assert list(p.index) == [0, 1, 2]
-    p = n._pair_segment_values(8.0, 9.0)
-    assert list(p.columns) == [1, 2]
-    assert list(p.index) == [0, 1, 2]
-    expected[0, 1] = 9.0
-    np.testing.assert_equal(p, expected)
-    p = n._pair_segment_values(8.0, 9.0, name='foo')
-    assert list(p.columns) == ['foo1', 'foo2']
-    assert list(p.index) == [0, 1, 2]
-    np.testing.assert_equal(p, expected)
+    pd.testing.assert_frame_equal(
+        n.pair_segments_df(8.0),
+        pd.DataFrame({1: 8.0, 2: 8.0}, index=[0, 1, 2]))
+    pd.testing.assert_frame_equal(
+        n.pair_segments_df(8.0, name="foo"),
+        pd.DataFrame({"foo1": 8.0, "foo2": 8.0}, index=[0, 1, 2]))
+    pd.testing.assert_frame_equal(
+        n.pair_segments_df(8, 9),
+        pd.DataFrame({1: 8, 2: [9, 8, 8]}))
+    pd.testing.assert_frame_equal(
+        n.pair_segments_df(8, 9, name="foo"),
+        pd.DataFrame({"foo1": 8, "foo2": [9, 8, 8]}))
     # from list
-    p = n._pair_segment_values([3, 4, 5])
-    assert list(p.columns) == [1, 2]
-    assert list(p.index) == [0, 1, 2]
-    expected = np.array([
-            [3, 3],
-            [4, 3],
-            [5, 3]])
-    np.testing.assert_equal(p, expected)
-    p = n._pair_segment_values([3, 4, 5], name='foo')
-    assert list(p.columns) == ['foo1', 'foo2']
-    assert list(p.index) == [0, 1, 2]
-    np.testing.assert_equal(p, expected)
-    p = n._pair_segment_values([3, 4, 5], [6])
-    assert list(p.columns) == [1, 2]
-    assert list(p.index) == [0, 1, 2]
-    expected[0, 1] = 6
-    p = n._pair_segment_values([3, 4, 5], [6], name='foo')
-    assert list(p.columns) == ['foo1', 'foo2']
-    assert list(p.index) == [0, 1, 2]
-    np.testing.assert_equal(p, expected)
-    p = n._pair_segment_values([3, 4, 5], 6)
-    assert list(p.columns) == [1, 2]
-    assert list(p.index) == [0, 1, 2]
-    np.testing.assert_equal(p, expected)
-    p = n._pair_segment_values(['$VAL1$', '$VAL2$', '$VAL3$'])
-    assert list(p.columns) == [1, 2]
-    assert list(p.index) == [0, 1, 2]
-    expected = np.array([
-            ['$VAL1$', '$VAL1$'],
-            ['$VAL2$', '$VAL1$'],
-            ['$VAL3$', '$VAL1$']])
-    np.testing.assert_equal(p, expected)
-    p = n._pair_segment_values(['$VAL1$', '$VAL2$', '$VAL3$'], ['$OUT1$'])
-    assert list(p.columns) == [1, 2]
-    assert list(p.index) == [0, 1, 2]
-    expected[0, 1] = '$OUT1$'
-    np.testing.assert_equal(p, expected)
-    return
+    pd.testing.assert_frame_equal(
+        n.pair_segments_df([3, 4, 5]),
+        pd.DataFrame({1: [3, 4, 5], 2: 3}))
+    pd.testing.assert_frame_equal(
+        n.pair_segments_df([3, 4, 5], name="foo"),
+        pd.DataFrame({"foo1": [3, 4, 5], "foo2": 3}))
+    pd.testing.assert_frame_equal(
+        n.pair_segments_df([3, 4, 5], [6]),
+        pd.DataFrame({1: [3, 4, 5], 2: [6, 3, 3]}))
+    pd.testing.assert_frame_equal(
+        n.pair_segments_df([3, 4, 5], [6], "foo"),
+        pd.DataFrame({"foo1": [3, 4, 5], "foo2": [6, 3, 3]}))
+    pd.testing.assert_frame_equal(
+        n.pair_segments_df(["$VAL1$", "$VAL2$", "$VAL3$"]),
+        pd.DataFrame({1: ["$VAL1$", "$VAL2$", "$VAL3$"], 2: "$VAL1$"}))
+    pd.testing.assert_frame_equal(
+        n.pair_segments_df(["v1", "v2", "v3"], ["o1"]),
+        pd.DataFrame({1: ["v1", "v2", "v3"], 2: ["o1", "v1", "v1"]}))
+    with pytest.raises(ValueError, match=errmsg_segments):
+        n.pair_segments_df([3, 4])
+    with pytest.raises(ValueError, match=errmsg_outlets):
+        n.pair_segments_df([3, 4, 5], [6, 7])
     # from Series
-    s1 = pd.Series([3, 4, 5])
-    s1.name = 'foo'
-    p = n._pair_segment_values(s1)
-    assert list(p.columns) == ['foo1', 'foo2']
-    assert list(p.index) == [0, 1, 2]
-    expected = np.array([
-            [3, 3],
-            [4, 3],
-            [5, 3]])
-    np.testing.assert_equal(p, expected)
-    p = n._pair_segment_values(s1, name='bar')
-    assert list(p.columns) == ['bar1', 'bar2']
-    assert list(p.index) == [0, 1, 2]
-    np.testing.assert_equal(p, expected)
-    so = pd.Series([6], index=[2])
-    expected[0, 1] = 6
-    p = n._pair_segment_values(s1, so)
-    assert list(p.columns) == ['foo1', 'foo2']
-    assert list(p.index) == [0, 1, 2]
-    np.testing.assert_equal(p, expected)
-    so.name = 'bar'  # should be ignored
-    p = n._pair_segment_values(s1, so)
-    assert list(p.columns) == ['foo1', 'foo2']
-    assert list(p.index) == [0, 1, 2]
-    np.testing.assert_equal(p, expected)
-    p = n._pair_segment_values(s1, so, name='zap')
-    assert list(p.columns) == ['zap1', 'zap2']
-    assert list(p.index) == [0, 1, 2]
-    np.testing.assert_equal(p, expected)
+    pd.testing.assert_frame_equal(
+        n.pair_segments_df(pd.Series([3, 4, 5])),
+        pd.DataFrame({1: [3, 4, 5], 2: 3}))
+    pd.testing.assert_frame_equal(
+        n.pair_segments_df(pd.Series([3, 4, 5]), name="foo"),
+        pd.DataFrame({"foo1": [3, 4, 5], "foo2": 3}))
+    pd.testing.assert_frame_equal(
+        n.pair_segments_df(pd.Series([3, 4, 5]), pd.Series(6)),
+        pd.DataFrame({1: [3, 4, 5], 2: [6, 3, 3]}))
+    # mixed with dict
+    pd.testing.assert_frame_equal(
+        n.pair_segments_df([3, 4, 5], {0: 6}),
+        pd.DataFrame({1: [3, 4, 5], 2: [6, 3, 3]}))
+    with pytest.raises(ValueError, match=errmsg_outlets):
+        n.pair_segments_df(1, {1: 2})
+    # allow mixed types
+    pd.testing.assert_frame_equal(
+        n.pair_segments_df([3, 4, 5], [6.0]),
+        pd.DataFrame({1: [3, 4, 5], 2: [6.0, 3.0, 3.0]}))
+    pd.testing.assert_frame_equal(
+        n.pair_segments_df([3, 4, 5], ["out"]),
+        pd.DataFrame({1: [3, 4, 5], 2: ["out", 3, 3]}))
+    # misc errors
+    with pytest.raises(ValueError, match="expected value to be scalar, list,"):
+        n.pair_segments_df(object())
+    with pytest.raises(ValueError, match="expected outlet_value to be scalar"):
+        n.pair_segments_df(1, object())
 
 
 def test_remove_condition():

--- a/tests/test_modflow.py
+++ b/tests/test_modflow.py
@@ -529,7 +529,7 @@ def test_default_segment_data(has_z):
     np.testing.assert_array_almost_equal(
         sd.width1, [1.4456947376374667, 1.439700753532406, 1.4615011177787172])
     np.testing.assert_array_almost_equal(
-        sd.width2, [1.4615011177787172, 1.461501117778717, 1.4615011177787172])
+        sd.width2, [1.4456947376374667, 1.439700753532406, 1.4615011177787172])
 
 
 @requires_mf2005
@@ -538,7 +538,7 @@ def test_n3d_vars(tmp_path):
     n = get_basic_swn()
     # manually add outside flow from extra segnums, referenced with inflow
     n.segments.at[1, "from_segnums"] = {3, 4}
-    m = get_basic_modflow(str(tmp_path), hk=1.0, rech=0.01)
+    m = get_basic_modflow(tmp_path, hk=1.0, rech=0.01)
     nm = swn.SwnModflow.from_swn_flopy(n, m)
     nm.set_reach_slope(min_slope=0.03)
     nm.default_segment_data(hyd_cond1=2, thickness1=2.0)
@@ -628,7 +628,7 @@ def test_n3d_vars(tmp_path):
 def test_n2d_defaults(tmp_path):
     # similar to 3D version, but getting information from model
     n = get_basic_swn(has_z=False)
-    m = get_basic_modflow(str(tmp_path), with_top=True, hk=1.0, rech=0.01)
+    m = get_basic_modflow(tmp_path, with_top=True, hk=1.0, rech=0.01)
     nm = swn.SwnModflow.from_swn_flopy(n, m)
     nm.default_segment_data()
     nm.set_sfr_obj(ipakcb=52, istcb2=-53)
@@ -675,7 +675,7 @@ def test_n2d_defaults(tmp_path):
 @requires_mf2005
 def test_n2d_min_slope(tmp_path):
     n = get_basic_swn(has_z=False)
-    m = get_basic_modflow(str(tmp_path), with_top=True, hk=1.0, rech=0.01)
+    m = get_basic_modflow(tmp_path, with_top=True, hk=1.0, rech=0.01)
     nm = swn.SwnModflow.from_swn_flopy(n, m)
     nm.set_reach_slope(min_slope=0.03)
     nm.default_segment_data()
@@ -712,7 +712,7 @@ def test_n2d_min_slope(tmp_path):
 @requires_mf2005
 def test_set_elevations(tmp_path):
     n = get_basic_swn(has_z=False)
-    m = get_basic_modflow(str(tmp_path), with_top=True, hk=1.0, rech=0.01)
+    m = get_basic_modflow(tmp_path, with_top=True, hk=1.0, rech=0.01)
     nm = swn.SwnModflow.from_swn_flopy(n, m)
     nm.default_segment_data()
     # fix elevations
@@ -883,6 +883,7 @@ def test_coastal(tmp_path, coastal_lines_gdf, coastal_flow_m):
     sd = m.sfr.segment_data[0]
     assert sd.flow.sum() > 0.0
     assert sd.pptsw.sum() == 0.0
+    np.testing.assert_array_equal(sd.width1, sd.width2)
     # check_number_sum_hex(
     #    sd.nseg, 17020, "55968016ecfb4e995fb5591bce55fea0")
     # check_number_sum_hex(


### PR DESCRIPTION
For `SurfaceWaterNetwork`, make these public functions:
* `segments_series` - Generate a Series along the segments index
* `pair_segments_frame` - Generate a DataFrame of paired values for top/bottom of segments

The new `method` argument has the following:
* `continuous` - downstream value is evaluated to be the same as the upstream value it connects to. This allows a                continuous network of values along the networks, such as elevation.
* `constant` - use constant values for each pair
* `additive` - downstream value is evaluated to be a fraction of tributaries that add to the upstream value it connects to.                Proportions of values for each tributary are preserved, but lengths of segments are ignored.

For `SwnModflow` and `SwnMf6`, change the following:
* `set_reach_data_from_segments`
  * Add `method` with default `None` to automatically choose `continuous` or `constant`
  * Rename `log10` to `log`, as the base is irrelevant

---

The other important change is that the default generated value for width has changed. Before it was effectively using `continuous`, which would unrealistically change stream widths that are connected to each other. A better method is now set as `constant`, where the stream width at the top of each segments remains constant until each confluence.

