### PR TITLE
Rename packagedata_df to packagedata_frame for consistency

### DIFF
--- a/swn/modflow/_swnmf6.py
+++ b/swn/modflow/_swnmf6.py
@@ -265,6 +265,7 @@ class SwnMf6(SwnModflowBase):
         ...    "LINESTRING (60 100, 60  80)",
         ...    "LINESTRING (40 130, 60 100)",
         ...    "LINESTRING (70 130, 60 100)"])
+        >>> lines.index += 100
         >>> n = swn.SurfaceWaterNetwork.from_lines(lines)
         >>> sim = flopy.mf6.MFSimulation()
         >>> _ = flopy.mf6.ModflowTdis(sim, nper=1, time_units="days")
@@ -274,17 +275,21 @@ class SwnMf6(SwnModflowBase):
         ...     length_units="meters", xorigin=30.0, yorigin=70.0)
         >>> nm = swn.SwnMf6.from_swn_flopy(n, gwf)
         >>> nm.default_packagedata()
-        >>> nm.packagedata_frame("native")
-             k  i  j       rlen  rwid   rgrd  rtp  rbth  rhk    man  ncon  ustrf  ndv
-        rno                                                                          
-        1    1  1  1  18.027756  10.0  0.001  1.0   1.0  1.0  0.024     1    1.0    0
-        2    1  1  2   6.009252  10.0  0.001  1.0   1.0  1.0  0.024     2    1.0    0
-        3    1  2  2  12.018504  10.0  0.001  1.0   1.0  1.0  0.024     2    1.0    0
-        4    1  1  2  21.081851  10.0  0.001  1.0   1.0  1.0  0.024     1    1.0    0
-        5    1  2  2  10.540926  10.0  0.001  1.0   1.0  1.0  0.024     2    1.0    0
-        6    1  2  2  10.000000  10.0  0.001  1.0   1.0  1.0  0.024     3    1.0    0
-        7    1  3  2  10.000000  10.0  0.001  1.0   1.0  1.0  0.024     1    1.0    0
-        >>> nm.packagedata_frame("flopy")
+        >>> nm.reaches["boundname"] = nm.reaches["segnum"]
+        >>> nm.reaches["aux1"] = 2.0 + nm.reaches.index / 10.0
+        >>> nm.packagedata_frame("native", auxiliary="aux1")
+             k  i  j       rlen  rwid   rgrd  ...    man  ncon  ustrf  ndv  aux1  boundname
+        rno                                   ...                                          
+        1    1  1  1  18.027756  10.0  0.001  ...  0.024     1    1.0    0   2.1        101
+        2    1  1  2   6.009252  10.0  0.001  ...  0.024     2    1.0    0   2.2        101
+        3    1  2  2  12.018504  10.0  0.001  ...  0.024     2    1.0    0   2.3        101
+        4    1  1  2  21.081851  10.0  0.001  ...  0.024     1    1.0    0   2.4        102
+        5    1  2  2  10.540926  10.0  0.001  ...  0.024     2    1.0    0   2.5        102
+        6    1  2  2  10.000000  10.0  0.001  ...  0.024     3    1.0    0   2.6        100
+        7    1  3  2  10.000000  10.0  0.001  ...  0.024     1    1.0    0   2.7        100
+        <BLANKLINE>
+        [7 rows x 15 columns]
+        >>> nm.packagedata_frame("flopy", boundname=False)
                 cellid       rlen  rwid   rgrd  rtp  rbth  rhk    man  ncon  ustrf  ndv
         rno                                                                            
         0    (0, 0, 0)  18.027756  10.0  0.001  1.0   1.0  1.0  0.024     1    1.0    0

--- a/tests/test_modflow6.py
+++ b/tests/test_modflow6.py
@@ -177,10 +177,10 @@ def test_n3d_defaults(tmp_path):
     assert list(r.from_rnos) == [set(), {1}, {2}, set(), {4}, {3, 5}, {6}]
     assert list(r.to_div) == [0, 0, 0, 0, 0, 0, 0]
     with pytest.raises(KeyError, match="missing 6 reach dataset"):
-        nm.packagedata_df("native")
+        nm.packagedata_frame("native")
     nm.set_reach_slope()
     with pytest.raises(KeyError, match="missing 5 reach dataset"):
-        nm.packagedata_df("native")
+        nm.packagedata_frame("native")
     nm.default_packagedata(hyd_cond1=1e-4)
     np.testing.assert_array_almost_equal(
         nm.reaches["rlen"],
@@ -363,8 +363,8 @@ def test_packagedata(tmp_path):
         ["rno", "cellid"] + partial_expected_cols
 
     # Check pandas frames
-    rn = nm.packagedata_df("native")
-    rf = nm.packagedata_df("flopy")
+    rn = nm.packagedata_frame("native")
+    rf = nm.packagedata_frame("flopy")
     assert list(rn.columns) == ["k", "i", "j"] + partial_expected_cols
     assert list(rf.columns) == ["cellid"] + partial_expected_cols
     assert list(rn.ncon) == [1, 2, 2, 1, 2, 3, 1]


### PR DESCRIPTION
Most pandas-related public functions that return a DataFrame are named with `_frame`, not `_df`, so this is a minor breaking change with `SwnMf6`.

Also, add "See also" and "Examples" docstrings, as wider documentation will eventually be out.