### PR TITLE
SwnModflowBase: Modify swn and model properties

### DIFF
--- a/swn/modflow/_swnmf6.py
+++ b/swn/modflow/_swnmf6.py
@@ -23,6 +23,8 @@ class SwnMf6(SwnModflowBase):
 
     Attributes
     ----------
+    swn : swn.SurfaceWaterNetwork
+        Instance of a SurfaceWaterNetwork.
     model : flopy.mf6.ModflowGwf
         Instance of flopy.mf6.ModflowGwf
     segments : geopandas.GeoDataFrame

--- a/swn/modflow/_swnmf6.py
+++ b/swn/modflow/_swnmf6.py
@@ -198,36 +198,6 @@ class SwnMf6(SwnModflowBase):
         super().__setstate__(state)
         self.tsvar = state["tsvar"]
 
-    @SwnModflowBase.model.setter
-    def model(self, model):
-        """Set model property."""
-        import flopy
-        if not (isinstance(model, flopy.mf6.mfmodel.MFModel)):
-            raise ValueError(
-                "'model' must be a flopy.mf6.MFModel object; found " +
-                str(type(model)))
-        sim = model.simulation
-        if "tdis" not in sim.package_key_dict.keys():
-            raise ValueError("TDIS package required")
-        if "dis" not in model.package_type_dict.keys():
-            raise ValueError("DIS package required")
-        _model = getattr(self, "_model", None)
-        if _model is not None and _model is not model:
-            self.logger.info("swapping 'model' object")
-        self._model = model
-        # Build stress period DataFrame from modflow model
-        stress_df = pd.DataFrame(
-            {"perlen": sim.tdis.perioddata.array.perlen})
-        modeltime = self.model.modeltime
-        stress_df["duration"] = pd.TimedeltaIndex(
-            stress_df["perlen"].cumsum(), modeltime.time_units)
-        stress_df["start"] = pd.to_datetime(modeltime.start_datetime)
-        stress_df["end"] = stress_df["duration"] + stress_df.at[0, "start"]
-        stress_df.loc[1:, "start"] = stress_df["end"].iloc[:-1].values
-        self._stress_df = stress_df  # keep this for debugging
-        self.time_index = pd.DatetimeIndex(stress_df["start"]).copy()
-        self.time_index.name = None
-
     def packagedata_frame(
             self, style: str, auxiliary: list = [], boundname=None):
         """Return DataFrame of PACKAGEDATA for MODFLOW 6 SFR.

--- a/swn/modflow/_swnmodflow.py
+++ b/swn/modflow/_swnmodflow.py
@@ -24,6 +24,8 @@ class SwnModflow(SwnModflowBase):
 
     Attributes
     ----------
+    swn : swn.SurfaceWaterNetwork
+        Instance of a SurfaceWaterNetwork.
     model : flopy.modflow.Modflow
         Instance of flopy.modflow.Modflow
     segments : geopandas.GeoDataFrame

--- a/swn/modflow/_swnmodflow.py
+++ b/swn/modflow/_swnmodflow.py
@@ -189,34 +189,6 @@ class SwnModflow(SwnModflowBase):
         self.segment_data = state["segment_data"]
         self.segment_data_ts = state["segment_data_ts"]
 
-    @SwnModflowBase.model.setter
-    def model(self, model):
-        """Set model property from flopy.modflow.Modflow."""
-        import flopy
-        if not isinstance(model, flopy.modflow.Modflow):
-            raise ValueError(
-                "'model' must be a flopy Modflow object; found " +
-                str(type(model)))
-        elif not model.has_package("DIS"):
-            raise ValueError("DIS package required")
-        elif not model.has_package("BAS6"):
-            raise ValueError("BAS6 package required")
-        _model = getattr(self, "_model", None)
-        if _model is not None and _model is not model:
-            self.logger.info("swapping 'model' object")
-        self._model = model
-        # Build stress period DataFrame from modflow model
-        stress_df = pd.DataFrame({"perlen": self.model.dis.perlen.array})
-        modeltime = self.model.modeltime
-        stress_df["duration"] = pd.TimedeltaIndex(
-            stress_df["perlen"].cumsum(), modeltime.time_units)
-        stress_df["start"] = pd.to_datetime(modeltime.start_datetime)
-        stress_df["end"] = stress_df["duration"] + stress_df.at[0, "start"]
-        stress_df.loc[1:, "start"] = stress_df["end"].iloc[:-1].values
-        self._stress_df = stress_df  # keep this for debugging
-        self.time_index = pd.DatetimeIndex(stress_df["start"]).copy()
-        self.time_index.name = None
-
     def new_segment_data(self):
         """Generate an empty segment_data DataFrame.
 

--- a/tests/test_modflow.py
+++ b/tests/test_modflow.py
@@ -1394,7 +1394,9 @@ def test_pickle(tmp_path):
     data = pickle.dumps(nm1)
     nm2 = pickle.loads(data)
     assert nm1 != nm2
+    assert nm2.swn is None
     assert nm2.model is None
+    nm2.swn = n
     nm2.model = m
     assert nm1 == nm2
     # use to_pickle / from_pickle methods
@@ -1404,5 +1406,5 @@ def test_pickle(tmp_path):
     nm3 = swn.SwnModflow.from_swn_flopy(n, m)
     nm3.default_segment_data(hyd_cond1=0.0)
     nm3.to_pickle(tmp_path / "nm4.pickle")
-    nm4 = swn.SwnModflow.from_pickle(tmp_path / "nm4.pickle", m)
+    nm4 = swn.SwnModflow.from_pickle(tmp_path / "nm4.pickle", n, m)
     assert nm3 == nm4

--- a/tests/test_modflow.py
+++ b/tests/test_modflow.py
@@ -309,8 +309,8 @@ def test_n3d_defaults(tmp_path):
 def test_model_property():
     nm = swn.SwnModflow()
     with pytest.raises(
-            ValueError, match="'model' must be a flopy Modflow object"):
-        nm.model = None
+            ValueError, match="model must be a flopy Modflow object"):
+        nm.model = 0
 
     m = flopy.modflow.Modflow()
     with pytest.raises(ValueError, match="DIS package required"):
@@ -325,12 +325,16 @@ def test_model_property():
 
     _ = flopy.modflow.ModflowBas(m, strt=15.0, stoper=5.0)
 
+    assert not hasattr(nm, "time_index")
+    assert not hasattr(nm, "grid_cells")
+
     # Success!
     nm.model = m
 
     pd.testing.assert_index_equal(
         nm.time_index,
         pd.DatetimeIndex(["2001-02-03"], dtype="datetime64[ns]"))
+    assert nm.grid_cells.shape == (6, 2)
 
     # Swap model with same and with another
     nm.model = m

--- a/tests/test_modflow.py
+++ b/tests/test_modflow.py
@@ -337,11 +337,31 @@ def test_model_property():
     assert nm.grid_cells.shape == (6, 2)
 
     # Swap model with same and with another
+    # same object
     nm.model = m
-    m2 = flopy.modflow.Modflow()
-    _ = flopy.modflow.ModflowDis(m2)
-    _ = flopy.modflow.ModflowBas(m2)
-    nm.model = m2
+
+    dis_args = {
+        "nper": 1, "nlay": 1, "nrow": 3, "ncol": 2, "delr": 20.0, "delc": 20.0,
+        "xul": 30.0, "yul": 130.0, "start_datetime": "2001-03-02"}
+    m = flopy.modflow.Modflow()
+    _ = flopy.modflow.ModflowDis(m, **dis_args)
+    _ = flopy.modflow.ModflowBas(m)
+    # this is allowed
+    nm.model = m
+
+    dis_args_replace = {
+        "nper": 2, "nrow": 4, "ncol": 3, "delr": 30.0, "delc": 40.0,
+        "xul": 20.0, "yul": 120.0}
+    for vn, vr in dis_args_replace.items():
+        # print(f"{vn}: {vr}")
+        dis_args_use = dis_args.copy()
+        dis_args_use[vn] = vr
+        m = flopy.modflow.Modflow()
+        _ = flopy.modflow.ModflowDis(m, **dis_args_use)
+        _ = flopy.modflow.ModflowBas(m)
+        # this is not allowed
+        with pytest.raises(AttributeError, match="properties are too differe"):
+            nm.model = m
 
 
 def test_set_segment_data_from_scalar():

--- a/tests/test_modflow6.py
+++ b/tests/test_modflow6.py
@@ -693,7 +693,9 @@ def test_pickle(tmp_path):
     data = pickle.dumps(nm1)
     nm2 = pickle.loads(data)
     assert nm1 != nm2
+    assert nm2.swn is None
     assert nm2.model is None
+    nm2.swn = n
     nm2.model = m
     assert nm1 == nm2
     # use to_pickle / from_pickle methods
@@ -702,5 +704,5 @@ def test_pickle(tmp_path):
     n.set_diversions(diversions=diversions)
     nm3 = swn.SwnMf6.from_swn_flopy(n, m)
     nm3.to_pickle(tmp_path / "nm4.pickle")
-    nm4 = swn.SwnMf6.from_pickle(tmp_path / "nm4.pickle", m)
+    nm4 = swn.SwnMf6.from_pickle(tmp_path / "nm4.pickle", n, m)
     assert nm3 == nm4

--- a/tests/test_modflow6.py
+++ b/tests/test_modflow6.py
@@ -265,7 +265,7 @@ def test_model_property():
             ValueError, match="model must be a flopy.mf6.MFModel object"):
         nm.model = 0
 
-    sim = flopy.mf6.MFSimulation(exe_name=mf6_exe)
+    sim = flopy.mf6.MFSimulation()
     m = flopy.mf6.MFModel(sim)
 
     with pytest.raises(ValueError, match="TDIS package required"):
@@ -300,9 +300,47 @@ def test_model_property():
     assert nm.grid_cells.shape == (6, 2)
 
     # Swap model with same and with another
-    m2 = flopy.mf6.ModflowGwf(sim, modelname="another")
-    _ = flopy.mf6.ModflowGwfdis(m2, idomain=1)
-    nm.model = m2
+    # same object
+    nm.model = m
+
+    tdis_args = {
+        "nper": 1, "time_units": "days", "start_date_time": "2001-02-03"}
+    dis_args = {
+        "nlay": 1, "nrow": 3, "ncol": 2, "delr": 20.0, "delc": 20.0,
+        "length_units": "meters", "xorigin": 30.0, "yorigin": 70.0,
+        "idomain": 1}
+    sim = flopy.mf6.MFSimulation()
+    m = flopy.mf6.MFModel(sim)
+    _ = flopy.mf6.ModflowTdis(sim, **tdis_args)
+    _ = flopy.mf6.ModflowGwfdis(m, **dis_args)
+    # this is allowed
+    nm.model = m
+
+    tdis_args_replace = {"nper": 2}
+    for vn, vr in tdis_args_replace.items():
+        print(f"{vn}: {vr}")
+        tdis_args_use = tdis_args.copy()
+        tdis_args_use[vn] = vr
+        sim = flopy.mf6.MFSimulation()
+        m = flopy.mf6.MFModel(sim)
+        _ = flopy.mf6.ModflowTdis(sim, **tdis_args_use)
+        _ = flopy.mf6.ModflowGwfdis(m, **dis_args)
+        # this is not allowed
+        with pytest.raises(AttributeError, match="properties are too differe"):
+            nm.model = m
+    dis_args_replace = {
+        "nrow": 4, "ncol": 3, "delr": 30.0, "delc": 40.0,
+        "xorigin": 20.0, "yorigin": 60.0}
+    for vn, vr in dis_args_replace.items():
+        dis_args_use = dis_args.copy()
+        dis_args_use[vn] = vr
+        sim = flopy.mf6.MFSimulation()
+        m = flopy.mf6.MFModel(sim)
+        _ = flopy.mf6.ModflowTdis(sim, **tdis_args)
+        _ = flopy.mf6.ModflowGwfdis(m, **dis_args_use)
+        # this is not allowed
+        with pytest.raises(AttributeError, match="properties are too differe"):
+            nm.model = m
 
 
 def test_set_reach_data_from_array():

--- a/tests/test_modflow_base.py
+++ b/tests/test_modflow_base.py
@@ -67,6 +67,17 @@ def get_basic_modflow(with_top: bool = False, nper: int = 1):
     return m
 
 
+def test_swn_property():
+    n = get_basic_swn(False)
+    nm = swn.SwnModflow()
+    assert nm.swn is None
+    nm.swn = n
+    assert nm.swn is not None
+    assert nm.swn is n
+    with pytest.raises(AttributeError, match="swn property can only be set o"):
+        nm.swn = n
+
+
 @pytest.mark.parametrize(
     "has_z", [False, True], ids=["n2d", "n3d"])
 def test_from_swn_flopy_defaults(has_z):


### PR DESCRIPTION
* Move `grid_cells` construction to `model` property
* Allow `model` property to be set more than once, so long as some spatial/temporal properties remain the same
* Add `swn` property, which should be set only once
* Limit a few properties from pickle format
* Fix `.plot()` depending if `model` and/or `swn` properties are set

Closes #21