### PR TITLE
Increase minimum Python to 3.7 and pandas to 1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@ Creates surface water network, which can be used to create MODFLOW's SFR.
 
 ## Python packages
 
-Python 3.6+ is required.
+Python 3.7+ is required.
 
 ### Required
 
  - `geopandas` - process spatial data similar to pandas
- - `pyproj>=2.2` - spatial projection support
+ - `pandas >=1.2` - tabular data analysis
+ - `pyproj >=2.2` - spatial projection support
  - `rtree` - spatial index support
 
 ### Optional

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,6 +7,7 @@ Version 0.5
 :Date: dd mmm yyyy
 
 - Not released
+- Minimum requirements are Python 3.7, pandas 1.2
 
 Version 0.4
 -----------

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,9 +29,10 @@ project_urls =
 
 [options]
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     geopandas
+    pandas >= 1.2
     pyproj >= 2.2
     rtree
     shapely

--- a/swn/core.py
+++ b/swn/core.py
@@ -349,10 +349,10 @@ class SurfaceWaterNetwork:
         for numiter in range(1, obj.segments['num_to_outlet'].max() + 1):
             # Gather segments downstream from completed upstream set
             downstream = set(
-                obj.segments.loc[completed, 'to_segnum'])\
+                obj.segments.loc[sorted(completed), 'to_segnum'])\
                 .difference(completed.union([obj.END_SEGNUM]))
             # Sort them to evaluate the furthest first
-            downstream_sorted = obj.segments.loc[downstream]\
+            downstream_sorted = obj.segments.loc[sorted(downstream)]\
                 .sort_values(search_order, ascending=False).index
             for segnum in downstream_sorted:
                 if from_segnums[segnum].issubset(completed):
@@ -904,7 +904,7 @@ class SurfaceWaterNetwork:
             if len(up_segnums) == 1:
                 yield from up_path_headwater_segnums(up_segnums.pop())
             elif len(up_segnums) > 1:
-                up_segnum = self.segments.loc[up_segnums].sort_values(
+                up_segnum = self.segments.loc[sorted(up_segnums)].sort_values(
                     follow_up, ascending=False).index[0]
                 # self.logger.debug('untraced path %s: %s -> %s',
                 #                   segnum, up_segnums, up_segnum)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -325,7 +325,7 @@ def test_to_segnums(valid_n):
     # check series in propery method
     pd.testing.assert_series_equal(
         valid_n.to_segnums,
-        pd.Series([0, 0], name="to_segnum", index=pd.Int64Index([1, 2])))
+        pd.Series([0, 0], name="to_segnum", index=pd.Index([1, 2], int)))
     # check series in segments frame
     pd.testing.assert_series_equal(
         valid_n.segments["to_segnum"],
@@ -338,7 +338,7 @@ def test_to_segnums(valid_n):
     pd.testing.assert_series_equal(
         n.to_segnums,
         pd.Series([0, 0], name="to_segnum",
-                  index=pd.Int64Index([1, 2], name="idx")))
+                  index=pd.Index([1, 2], int, name="idx")))
     pd.testing.assert_series_equal(
         n.segments["to_segnum"],
         pd.Series([-1, 0, 0], name="to_segnum",
@@ -362,7 +362,7 @@ def test_from_segnums(valid_n):
     pd.testing.assert_series_equal(
         n.from_segnums,
         pd.Series([{1, 2}], name="from_segnums",
-                  index=pd.Int64Index([0], name="idx")))
+                  index=pd.Index([0], int, name="idx")))
     pd.testing.assert_series_equal(
         n.segments["from_segnums"],
         pd.Series([{1, 2}, set(), set()], name="from_segnums",

--- a/tests/test_modflow.py
+++ b/tests/test_modflow.py
@@ -194,7 +194,7 @@ def test_new_segment_data(has_diversions):
     if has_diversions:
         pd.testing.assert_index_equal(
             nm.segment_data.index,
-            pd.Int64Index([1, 2, 3, 4, 5, 6, 7], name="nseg"))
+            pd.Index([1, 2, 3, 4, 5, 6, 7], int, name="nseg"))
         assert list(nm.segment_data.segnum) == [1, 2, 0, -1, -1, -1, -1]
         assert list(nm.segment_data.divid) == [0, 0, 0, 0, 1, 2, 3]
         assert list(nm.segment_data.outseg) == [3, 3, 0, 0, 0, 0, 0]
@@ -202,7 +202,7 @@ def test_new_segment_data(has_diversions):
     else:
         pd.testing.assert_index_equal(
             nm.segment_data.index,
-            pd.Int64Index([1, 2, 3], name="nseg"))
+            pd.Index([1, 2, 3], int, name="nseg"))
         assert list(nm.segment_data.segnum) == [1, 2, 0]
         assert "divid" not in nm.segment_data.columns
         assert list(nm.segment_data.outseg) == [3, 3, 0]

--- a/tests/test_modflow_base.py
+++ b/tests/test_modflow_base.py
@@ -696,7 +696,7 @@ def test_transform_data_from_dict():
     time_index = pd.DatetimeIndex(["2000-07-01", "2000-07-02"])
     mapping = pd.Series(
         [1, 2, 3], name="nseg",
-        index=pd.Int64Index([1, 2, 0], name="segnum"))
+        index=pd.Index([1, 2, 0], int, name="segnum"))
 
     # returns series
     pd.testing.assert_series_equal(
@@ -784,7 +784,7 @@ def test_transform_data_from_series():
     time_index = pd.DatetimeIndex(["2000-07-01", "2000-07-02"])
     mapping = pd.Series(
         [1, 2, 3], name="nseg",
-        index=pd.Int64Index([1, 2, 0], name="segnum"))
+        index=pd.Index([1, 2, 0], int, name="segnum"))
 
     pd.testing.assert_series_equal(
         f(pd.Series(dtype=float), float, time_index),
@@ -837,7 +837,7 @@ def test_transform_data_from_frame():
     time_index = pd.DatetimeIndex(["2000-07-01", "2000-07-02"])
     mapping = pd.Series(
         [1, 2, 3], name="nseg",
-        index=pd.Int64Index([1, 2, 0], name="segnum"))
+        index=pd.Index([1, 2, 0], int, name="segnum"))
 
     pd.testing.assert_frame_equal(
         f(pd.DataFrame(dtype=float, index=time_index), float, time_index),


### PR DESCRIPTION
Also resolve two FutureWarning for pandas:

- pandas.Int64Index is deprecated
- Passing a set as an indexer is deprecated