### PR TITLE
Add properties for SwnModflow: segment_data and _ts, improve examples

### DIFF
--- a/docs/source/swnmodflow.rst
+++ b/docs/source/swnmodflow.rst
@@ -13,6 +13,17 @@ Constructors
    SwnModflow.from_swn_flopy
    SwnModflow.from_pickle
 
+Data generation
+---------------
+.. autosummary::
+   :toctree: ref/
+
+   SwnModflow.new_segment_data
+   SwnModflow.default_segment_data
+   SwnModflow.set_segment_data_from_scalar
+   SwnModflow.set_segment_data_from_segments
+   SwnModflow.set_segment_data_from_diversions
+
 DataFrame properties
 --------------------
 
@@ -21,6 +32,7 @@ DataFrame properties
 
    SwnModflow.reaches
    SwnModflow.segment_data
+   SwnModflow.segment_data_ts
 
 Other properties
 ----------------

--- a/swn/core.py
+++ b/swn/core.py
@@ -181,8 +181,7 @@ class SurfaceWaterNetwork:
         Examples
         --------
         >>> import swn
-        >>> from swn.spatial import wkt_to_geoseries
-        >>> lines = wkt_to_geoseries([
+        >>> lines = swn.spatial.wkt_to_geoseries([
         ...    "LINESTRING (60 100, 60  80)",
         ...    "LINESTRING (40 130, 60 100)",
         ...    "LINESTRING (70 130, 60 100)"])
@@ -428,8 +427,7 @@ class SurfaceWaterNetwork:
         Examples
         --------
         >>> import swn
-        >>> from swn.spatial import wkt_to_geoseries
-        >>> lines = wkt_to_geoseries([
+        >>> lines = swn.spatial.wkt_to_geoseries([
         ...    "LINESTRING (60 100, 60  80)",
         ...    "LINESTRING (40 130, 60 100)",
         ...    "LINESTRING (70 130, 60 100)"])
@@ -460,13 +458,12 @@ class SurfaceWaterNetwork:
         Examples
         --------
         >>> import swn
-        >>> from swn.spatial import wkt_to_geoseries
-        >>> lines = wkt_to_geoseries([
+        >>> lines = swn.spatial.wkt_to_geoseries([
         ...    "LINESTRING (60 100, 60  80)",
         ...    "LINESTRING (40 130, 60 100)",
         ...    "LINESTRING (70 130, 60 100)"])
         >>> lines.index += 100
-        >>> polygons = wkt_to_geoseries([
+        >>> polygons = swn.spatial.wkt_to_geoseries([
         ...    "POLYGON ((35 100, 75 100, 75  80, 35  80, 35 100))",
         ...    "POLYGON ((35 135, 60 135, 60 100, 35 100, 35 135))",
         ...    "POLYGON ((60 135, 75 135, 75 100, 60 100, 60 135))"])
@@ -495,7 +492,8 @@ class SurfaceWaterNetwork:
             return
         elif not isinstance(value, geopandas.GeoSeries):
             raise ValueError(
-                f'catchments must be a GeoSeries or None; found {type(value)!r}')
+                "catchments must be a GeoSeries or None; "
+                f"found {type(value)!r}")
         segments_index = self.segments.index
         if (len(value.index) != len(segments_index) or
                 not (value.index == segments_index).all()):
@@ -1075,8 +1073,7 @@ class SurfaceWaterNetwork:
         Examples
         --------
         >>> import swn
-        >>> from swn.spatial import wkt_to_geoseries
-        >>> lines = wkt_to_geoseries([
+        >>> lines = swn.spatial.wkt_to_geoseries([
         ...    "LINESTRING (60 100, 60  80)",
         ...    "LINESTRING (40 130, 60 100)",
         ...    "LINESTRING (70 130, 60 100)"])
@@ -1156,8 +1153,7 @@ class SurfaceWaterNetwork:
         Examples
         --------
         >>> import swn
-        >>> from swn.spatial import wkt_to_geoseries
-        >>> lines = wkt_to_geoseries([
+        >>> lines = swn.spatial.wkt_to_geoseries([
         ...    "LINESTRING (60 100, 60  80)",
         ...    "LINESTRING (40 130, 60 100)",
         ...    "LINESTRING (70 130, 60 100)"])

--- a/swn/modflow/_misc.py
+++ b/swn/modflow/_misc.py
@@ -128,7 +128,8 @@ def transform_data_to_series_or_frame(
                 setattr(keys, keys_name, new_index)
             except (ValueError, TypeError):
                 raise ValueError(
-                      f"cannot cast {keys_name}.dtype to {mapping.index.dtype}")
+                      f"cannot cast {keys_name}.dtype to "
+                      f"{mapping.index.dtype}")
             keys_s = set(new_index.values)
         idxname = mapping.index.name
         index_s = set(mapping.index)

--- a/swn/modflow/_swnmf6.py
+++ b/swn/modflow/_swnmf6.py
@@ -229,8 +229,7 @@ class SwnMf6(SwnModflowBase):
         --------
         >>> import flopy
         >>> import swn
-        >>> from swn.spatial import wkt_to_geoseries
-        >>> lines = wkt_to_geoseries([
+        >>> lines = swn.spatial.wkt_to_geoseries([
         ...    "LINESTRING (60 100, 60  80)",
         ...    "LINESTRING (40 130, 60 100)",
         ...    "LINESTRING (70 130, 60 100)"])

--- a/swn/spatial.py
+++ b/swn/spatial.py
@@ -254,7 +254,6 @@ def find_geom_in_swn(geom, n, override={}):
 
     Notes
     -----
-
     Seveal methods are used to pair the geometry with one segnum:
 
         1. override: explicit pairs are provided as a dict, with key for the
@@ -284,19 +283,18 @@ def find_geom_in_swn(geom, n, override={}):
     Examples
     --------
     >>> import swn
-    >>> from swn.spatial import find_geom_in_swn, wkt_to_geoseries
-    >>> lines = wkt_to_geoseries([
+    >>> lines = swn.spatial.wkt_to_geoseries([
     ...    "LINESTRING (60 100, 60  80)",
     ...    "LINESTRING (40 130, 60 100)",
     ...    "LINESTRING (70 130, 60 100)"])
     >>> n = swn.SurfaceWaterNetwork.from_lines(lines)
-    >>> obs_geom = wkt_to_geoseries([
+    >>> obs_gs = swn.spatial.wkt_to_geoseries([
     ...    "POINT (56 103)",
     ...    "LINESTRING (58 90, 62 90)",
     ...    "POLYGON ((60 107, 59 113, 61 113, 60 107))",
     ...    "POINT (55 130)"])
-    >>> obs_geom.index += 101
-    >>> obs_match = find_geom_in_swn(obs_geom, n, override={104: 2})
+    >>> obs_gs.index += 101
+    >>> obs_match = swn.spatial.find_geom_in_swn(obs_gs, n, override={104: 2})
     >>> print(obs_match[["method", "segnum", "seg_ndist", "dist_to_seg"]])
            method  segnum  seg_ndist  dist_to_seg
     101   nearest       1   0.869231     1.664101

--- a/tests/test_modflow.py
+++ b/tests/test_modflow.py
@@ -375,6 +375,93 @@ def test_time_index():
     assert list(nm.time_index.year) == [1999] * 6 + [2000] * 6
 
 
+def test_segment_data_property():
+    n = get_basic_swn(has_diversions=True)
+    m = get_basic_modflow(nper=2)
+    nm = swn.SwnModflow.from_swn_flopy(n, m)
+    assert nm.segment_data is None
+    assert nm.segment_data_ts is None
+    nm.segment_data = None
+    nm.segment_data_ts = None
+    assert nm.segment_data is None
+    assert nm.segment_data_ts is None
+    sd = pd.DataFrame(index=pd.Index(np.arange(7) + 1))
+    nm.segment_data = sd
+    assert nm.segment_data is sd
+    assert nm.segment_data_ts is None
+    sd_ts = {"data": pd.DataFrame(index=[0, 1])}
+    nm.segment_data_ts = sd_ts
+    assert nm.segment_data is sd
+    assert nm.segment_data_ts is sd_ts
+    nm.segment_data = None
+    assert nm.segment_data is None
+    assert nm.segment_data_ts is sd_ts
+    nm.segment_data_ts = None
+    assert nm.segment_data_ts is None
+    # Errors
+    with pytest.raises(ValueError, match="segment_data must be a DataFrame o"):
+        nm.segment_data = []
+    with pytest.raises(ValueError, match="segment_data nseg index is unexpec"):
+        nm.segment_data = pd.DataFrame()
+    with pytest.raises(ValueError, match="segment_data_ts must be a dict or "):
+        nm.segment_data_ts = pd.DataFrame()
+    with pytest.raises(ValueError, match="segment_data_ts key 'data' must be"):
+        nm.segment_data_ts = {"data": []}
+
+
+@pytest.mark.parametrize(
+    "has_z", [False, True], ids=["n2d", "n3d"])
+def test_default_segment_data(has_z):
+    n = get_basic_swn(has_z=has_z)
+    m = get_basic_modflow()
+    nm = swn.SwnModflow.from_swn_flopy(n, m)
+    assert nm.segment_data is None
+    assert nm.segment_data_ts is None
+    nm.default_segment_data()
+    assert nm.segment_data is not None
+    assert nm.segment_data_ts == {}
+    sd = nm.segment_data
+    assert sd.index.name == "nseg"
+    np.testing.assert_array_equal(sd.index, [1, 2, 3])
+    np.testing.assert_array_equal(sd.icalc, [1, 1, 1])
+    np.testing.assert_array_equal(sd.outseg, [3, 3, 0])
+    np.testing.assert_array_equal(sd.iupseg, [0, 0, 0])
+    np.testing.assert_array_equal(sd.iprior, [0, 0, 0])
+    np.testing.assert_array_almost_equal(sd.flow, [0.0, 0.0, 0.0])
+    np.testing.assert_array_almost_equal(sd.runoff, [0.0, 0.0, 0.0])
+    np.testing.assert_array_almost_equal(sd.etsw, [0.0, 0.0, 0.0])
+    np.testing.assert_array_almost_equal(sd.pptsw, [0.0, 0.0, 0.0])
+    np.testing.assert_array_almost_equal(sd.roughch, [0.024, 0.024, 0.024])
+    np.testing.assert_array_almost_equal(sd.hcond1, [1.0, 1.0, 1.0])
+    np.testing.assert_array_almost_equal(sd.thickm1, [1.0, 1.0, 1.0])
+    if has_z:
+        expected_elevup = [14.75, 14.66666667, 13.5]
+        expected_elevdn = [14.16666667, 14.16666667, 12.5]
+    else:
+        expected_elevup = [15.0, 15.0, 15.0]
+        expected_elevdn = [15.0, 15.0, 15.0]
+    np.testing.assert_array_almost_equal(sd.elevup, expected_elevup)
+    np.testing.assert_array_almost_equal(sd.width1, [10.0, 10.0, 10.0])
+    np.testing.assert_array_almost_equal(sd.hcond2, [1.0, 1.0, 1.0])
+    np.testing.assert_array_almost_equal(sd.thickm2, [1.0, 1.0, 1.0])
+    np.testing.assert_array_almost_equal(sd.elevdn, expected_elevdn)
+    np.testing.assert_array_almost_equal(sd.width2, [10.0, 10.0, 10.0])
+
+    # auto determine width
+    n.catchments = wkt_to_geoseries([
+        "POLYGON ((35 100, 75 100, 75  80, 35  80, 35 100))",
+        "POLYGON ((35 135, 60 135, 60 100, 35 100, 35 135))",
+        "POLYGON ((60 135, 75 135, 75 100, 60 100, 60 135))",
+    ])
+    nm = swn.SwnModflow.from_swn_flopy(n, m)
+    nm.default_segment_data()
+    sd = nm.segment_data
+    np.testing.assert_array_almost_equal(
+        sd.width1, [1.4456947376374667, 1.439700753532406, 1.4615011177787172])
+    np.testing.assert_array_almost_equal(
+        sd.width2, [1.4456947376374667, 1.439700753532406, 1.4615011177787172])
+
+
 def test_set_segment_data_from_scalar():
     n = get_basic_swn(has_diversions=True)
     m = get_basic_modflow(nper=2)
@@ -598,59 +685,6 @@ def test_set_segment_data_inflow(nper, inflow, expected):
     if matplotlib:
         _ = nm.plot()
         plt.close()
-
-
-@pytest.mark.parametrize(
-    "has_z", [False, True], ids=["n2d", "n3d"])
-def test_default_segment_data(has_z):
-    n = get_basic_swn(has_z=has_z)
-    m = get_basic_modflow()
-    nm = swn.SwnModflow.from_swn_flopy(n, m)
-    assert nm.segment_data is None
-    assert nm.segment_data_ts is None
-    nm.default_segment_data()
-    assert nm.segment_data is not None
-    assert nm.segment_data_ts == {}
-    sd = nm.segment_data
-    assert sd.index.name == "nseg"
-    np.testing.assert_array_equal(sd.index, [1, 2, 3])
-    np.testing.assert_array_equal(sd.icalc, [1, 1, 1])
-    np.testing.assert_array_equal(sd.outseg, [3, 3, 0])
-    np.testing.assert_array_equal(sd.iupseg, [0, 0, 0])
-    np.testing.assert_array_equal(sd.iprior, [0, 0, 0])
-    np.testing.assert_array_almost_equal(sd.flow, [0.0, 0.0, 0.0])
-    np.testing.assert_array_almost_equal(sd.runoff, [0.0, 0.0, 0.0])
-    np.testing.assert_array_almost_equal(sd.etsw, [0.0, 0.0, 0.0])
-    np.testing.assert_array_almost_equal(sd.pptsw, [0.0, 0.0, 0.0])
-    np.testing.assert_array_almost_equal(sd.roughch, [0.024, 0.024, 0.024])
-    np.testing.assert_array_almost_equal(sd.hcond1, [1.0, 1.0, 1.0])
-    np.testing.assert_array_almost_equal(sd.thickm1, [1.0, 1.0, 1.0])
-    if has_z:
-        expected_elevup = [14.75, 14.66666667, 13.5]
-        expected_elevdn = [14.16666667, 14.16666667, 12.5]
-    else:
-        expected_elevup = [15.0, 15.0, 15.0]
-        expected_elevdn = [15.0, 15.0, 15.0]
-    np.testing.assert_array_almost_equal(sd.elevup, expected_elevup)
-    np.testing.assert_array_almost_equal(sd.width1, [10.0, 10.0, 10.0])
-    np.testing.assert_array_almost_equal(sd.hcond2, [1.0, 1.0, 1.0])
-    np.testing.assert_array_almost_equal(sd.thickm2, [1.0, 1.0, 1.0])
-    np.testing.assert_array_almost_equal(sd.elevdn, expected_elevdn)
-    np.testing.assert_array_almost_equal(sd.width2, [10.0, 10.0, 10.0])
-
-    # auto determine width
-    n.catchments = wkt_to_geoseries([
-        "POLYGON ((35 100, 75 100, 75  80, 35  80, 35 100))",
-        "POLYGON ((35 135, 60 135, 60 100, 35 100, 35 135))",
-        "POLYGON ((60 135, 75 135, 75 100, 60 100, 60 135))",
-    ])
-    nm = swn.SwnModflow.from_swn_flopy(n, m)
-    nm.default_segment_data()
-    sd = nm.segment_data
-    np.testing.assert_array_almost_equal(
-        sd.width1, [1.4456947376374667, 1.439700753532406, 1.4615011177787172])
-    np.testing.assert_array_almost_equal(
-        sd.width2, [1.4456947376374667, 1.439700753532406, 1.4615011177787172])
 
 
 @requires_mf2005


### PR DESCRIPTION
This changes `SwnModflow` properties `segment_data` and `segment_data_ts`. Previously they were standard properties, but the changes use `@property` and `@name.setter` decorators. This allows docstrings for documentation.

Also, expand documentation and examples elsewhere.