### PR TITLE
Add route_segnums and route_reaches methods

### DIFF
--- a/docs/source/swn.rst
+++ b/docs/source/swn.rst
@@ -44,6 +44,7 @@ Methods
    SurfaceWaterNetwork.segments_series
    SurfaceWaterNetwork.pair_segments_frame
    SurfaceWaterNetwork.accumulate_values
+   SurfaceWaterNetwork.route_segnums
    SurfaceWaterNetwork.query
    SurfaceWaterNetwork.aggregate
    SurfaceWaterNetwork.evaluate_upstream_length

--- a/docs/source/swnmf6.rst
+++ b/docs/source/swnmf6.rst
@@ -33,3 +33,9 @@ Reach data generation
    SwnMf6.set_reach_data_from_segments
    SwnMf6.set_reach_slope
 
+Methods
+-------
+.. autosummary::
+   :toctree: ref/
+
+    SwnMf6.route_reaches

--- a/docs/source/swnmodflow.rst
+++ b/docs/source/swnmodflow.rst
@@ -46,3 +46,9 @@ Segment data generation
    SwnModflow.set_segment_data_from_segments
    SwnModflow.set_segment_data_from_diversions
 
+Methods
+-------
+.. autosummary::
+   :toctree: ref/
+
+    SwnModflow.route_reaches

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -964,6 +964,33 @@ def test_fluss_n(fluss_n):
         plt.close()
 
 
+def test_route_segnums(fluss_n):
+    n = fluss_n
+    assert n.route_segnums(18, 18) == [18]
+    assert n.route_segnums(17, 18) == [17, 18]
+    assert n.route_segnums(18, 17) == [18, 17]
+    assert n.route_segnums(6, 16) == [6, 8, 16]
+    assert n.route_segnums(16, 6) == [16, 8, 6]
+    assert n.route_segnums(15, 9) == [15, 10, 9]
+    assert n.route_segnums(9, 15) == [9, 10, 15]
+    assert n.route_segnums(0, 1, allow_indirect=True) == [0, 1]
+    assert n.route_segnums(0, 11, allow_indirect=True) == [0, 2, 6, 8, 9, 11]
+    # errors
+    with pytest.raises(IndexError, match="invalid start segnum -1"):
+        n.route_segnums(-1, 0)
+    with pytest.raises(IndexError, match="invalid end segnum -1"):
+        n.route_segnums(0, -1)
+    with pytest.raises(ConnectionError, match="0 does not connect to 1"):
+        n.route_segnums(0, 1)
+    with pytest.raises(ConnectionError, match="3 does not connect to 9"):
+        n.route_segnums(3, 9)
+    n2 = swn.SurfaceWaterNetwork.from_lines(n.segments.geometry.iloc[0:4])
+    with pytest.raises(ConnectionError, match="segment networks are disjoint"):
+        n2.route_segnums(0, 3)
+    with pytest.raises(ConnectionError, match="segment networks are disjoint"):
+        n2.route_segnums(0, 3, allow_indirect=True)
+
+
 def test_fluss_n_query_upstream(fluss_n):
     n = fluss_n
     assert set(n.query(upstream=0)) == {0}

--- a/tests/test_modflow.py
+++ b/tests/test_modflow.py
@@ -1541,3 +1541,32 @@ def test_pickle(tmp_path):
     nm3.to_pickle(tmp_path / "nm4.pickle")
     nm4 = swn.SwnModflow.from_pickle(tmp_path / "nm4.pickle", n, m)
     assert nm3 == nm4
+
+
+def test_route_reaches():
+    n1 = get_basic_swn(has_diversions=True)
+    lines2 = list(n1.segments.geometry)
+    lines2.append(wkt.loads("LINESTRING (40 90, 50 80)"))
+    n = swn.SurfaceWaterNetwork.from_lines(geopandas.GeoSeries(lines2))
+    m = get_basic_modflow(with_top=False)
+    nm = swn.SwnModflow.from_swn_flopy(n, m)
+    assert nm.route_reaches(8, 8) == [8]
+    assert nm.route_reaches(7, 8) == [7, 8]
+    assert nm.route_reaches(8, 7) == [8, 7]
+    assert nm.route_reaches(2, 7) == [2, 3, 7]
+    assert nm.route_reaches(7, 2) == [7, 3, 2]
+    assert nm.route_reaches(1, 7) == [1, 2, 3, 7]
+    assert nm.route_reaches(7, 1) == [7, 3, 2, 1]
+    assert nm.route_reaches(2, 4, allow_indirect=True) == [2, 3, 5, 4]
+    # errors
+    with pytest.raises(IndexError, match="invalid start reachID 0"):
+        nm.route_reaches(0, 1)
+    with pytest.raises(IndexError, match="invalid end reachID 0"):
+        nm.route_reaches(1, 0)
+    with pytest.raises(ConnectionError, match="1 does not connect to 4"):
+        nm.route_reaches(1, 4)
+    with pytest.raises(ConnectionError, match="reach networks are disjoint"):
+        nm.route_reaches(1, 6)
+    with pytest.raises(ConnectionError, match="reach networks are disjoint"):
+        nm.route_reaches(1, 6, allow_indirect=True)
+    # TODO: diversions?


### PR DESCRIPTION
Add three methods:

- `SurfaceWaterNetwork.route_segnums`
- `SwnMf6.route_reaches`
- `SwnModflow.route_reaches`

These generally do similar things: return a list of identifiers from start to end.