### PR TITLE
Rename SurfaceWaterNetwork method query to gather_segnums

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ n = swn.SurfaceWaterNetwork.from_pickle('network.pkl')
 Remove segments that meet a condition (stream order), or that are
 upstream/downstream from certain locations:
 ```python
-n.remove(n.segments.stream_order == 1, segnums=n.query(upstream=3047927))
+n.remove(
+    n.segments.stream_order == 1,
+    segnums=n.gather_segnums(upstream=3047927))
 ```
 
 Read flow data from a TopNet netCDF file, convert from m3/s to m3/day:

--- a/docs/source/swn.rst
+++ b/docs/source/swn.rst
@@ -45,7 +45,7 @@ Methods
    SurfaceWaterNetwork.pair_segments_frame
    SurfaceWaterNetwork.accumulate_values
    SurfaceWaterNetwork.route_segnums
-   SurfaceWaterNetwork.query
+   SurfaceWaterNetwork.gather_segnums
    SurfaceWaterNetwork.aggregate
    SurfaceWaterNetwork.evaluate_upstream_length
    SurfaceWaterNetwork.evaluate_upstream_area

--- a/swn/modflow/_base.py
+++ b/swn/modflow/_base.py
@@ -1436,9 +1436,9 @@ class SwnModflowBase:
         usegs = [segnum]
         dsegs = []
         if upstream:
-            usegs = self._swn.query(upstream=segnum)
+            usegs = self._swn.gather_segnums(upstream=segnum)
         if downstream:
-            dsegs = self._swn.query(downstream=segnum)
+            dsegs = self._swn.gather_segnums(downstream=segnum)
         segs = usegs + dsegs
         if segnum not in segs:
             self.logger.error(

--- a/swn/modflow/_swnmf6.py
+++ b/swn/modflow/_swnmf6.py
@@ -925,7 +925,7 @@ class SwnMf6(SwnModflowBase):
                 upreach_rtp = hdrch.rtp
             inc_up = hdrch.top - upreach_rtp
             # get profile of reaches from this headwater
-            dsegs = self._swn.query(downstream=hdrch.segnum)
+            dsegs = self._swn.gather_segnums(downstream=hdrch.segnum)
             segs = [hdrch.segnum] + dsegs
             reaches = self.reaches.loc[
                 self.reaches.segnum.isin(segs)].sort_index()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -991,60 +991,70 @@ def test_route_segnums(fluss_n):
         n2.route_segnums(0, 3, allow_indirect=True)
 
 
-def test_fluss_n_query_upstream(fluss_n):
+def test_query_deprecated(fluss_n):
     n = fluss_n
-    assert set(n.query(upstream=0)) == {0}
-    assert set(n.query(upstream=[2])) == {0, 1, 2}
-    assert set(n.query(upstream=8)) == {0, 1, 2, 3, 4, 5, 6, 7, 8}
-    assert set(n.query(upstream=9)) == {9, 10, 11, 12, 13, 14, 15}
-    assert set(n.query(upstream=17)) == {17}
-    assert len(set(n.query(upstream=18))) == 19
+    with pytest.deprecated_call():
+        assert set(n.query(upstream=[2])) == {0, 1, 2}
+    with pytest.deprecated_call():
+        assert n.query(downstream=0) == [2, 6, 8, 16, 18]
+
+
+def test_fluss_n_gather_segnums_upstream(fluss_n):
+    n = fluss_n
+    assert set(n.gather_segnums(upstream=0)) == {0}
+    assert set(n.gather_segnums(upstream=[2])) == {0, 1, 2}
+    assert set(n.gather_segnums(upstream=8)) == {0, 1, 2, 3, 4, 5, 6, 7, 8}
+    assert set(n.gather_segnums(upstream=9)) == {9, 10, 11, 12, 13, 14, 15}
+    assert set(n.gather_segnums(upstream=17)) == {17}
+    assert len(set(n.gather_segnums(upstream=18))) == 19
     # with barriers
-    assert len(set(n.query(upstream=18, barrier=17))) == 18
-    assert len(set(n.query(upstream=18, barrier=9))) == 13
-    assert set(n.query(upstream=9, barrier=8)) == {9, 10, 11, 12, 13, 14, 15}
-    assert set(n.query(upstream=16, barrier=[9, 5])) == \
+    assert len(set(n.gather_segnums(upstream=18, barrier=17))) == 18
+    assert len(set(n.gather_segnums(upstream=18, barrier=9))) == 13
+    assert set(n.gather_segnums(upstream=9, barrier=8)) == \
+        {9, 10, 11, 12, 13, 14, 15}
+    assert set(n.gather_segnums(upstream=16, barrier=[9, 5])) == \
         {0, 1, 2, 5, 6, 7, 8, 9, 16}
     # break it
     with pytest.raises(
             IndexError,
             match=r'upstream segnum \-1 not found in segments\.index'):
-        n.query(upstream=-1)
+        n.gather_segnums(upstream=-1)
     with pytest.raises(
             IndexError,
             match=r'2 upstream segments not found in segments\.index: \[19, '):
-        n.query(upstream=[18, 19, 20])
+        n.gather_segnums(upstream=[18, 19, 20])
     with pytest.raises(
             IndexError,
             match=r'barrier segnum \-1 not found in segments\.index'):
-        n.query(upstream=18, barrier=-1)
+        n.gather_segnums(upstream=18, barrier=-1)
     with pytest.raises(
             IndexError,
             match=r'1 barrier segment not found in segments\.index: \[\-1\]'):
-        n.query(upstream=18, barrier=[-1, 15])
+        n.gather_segnums(upstream=18, barrier=[-1, 15])
 
 
-def test_fluss_n_query_downstream(fluss_n):
+def test_fluss_n_gather_segnums_downstream(fluss_n):
     n = fluss_n
-    assert n.query(downstream=0) == [2, 6, 8, 16, 18]
-    assert n.query(downstream=[2]) == [6, 8, 16, 18]
-    assert n.query(downstream=8) == [16, 18]
-    assert n.query(downstream=9) == [16, 18]
-    assert n.query(downstream=17) == [18]
-    assert n.query(downstream=18) == []
-    assert set(n.query(downstream=7, gather_upstream=True)) == \
+    assert n.gather_segnums(downstream=0) == [2, 6, 8, 16, 18]
+    assert n.gather_segnums(downstream=[2]) == [6, 8, 16, 18]
+    assert n.gather_segnums(downstream=8) == [16, 18]
+    assert n.gather_segnums(downstream=9) == [16, 18]
+    assert n.gather_segnums(downstream=17) == [18]
+    assert n.gather_segnums(downstream=18) == []
+    assert set(n.gather_segnums(downstream=7, gather_upstream=True)) == \
         {0, 1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18}
-    assert set(n.query(downstream=8, gather_upstream=True)) == \
+    assert set(n.gather_segnums(downstream=8, gather_upstream=True)) == \
         {9, 10, 11, 12, 13, 14, 15, 16, 17, 18}
-    assert set(n.query(downstream=[9], gather_upstream=True)) == \
+    assert set(n.gather_segnums(downstream=[9], gather_upstream=True)) == \
         {0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 17, 18}
-    assert n.query(downstream=18, gather_upstream=True) == []
-    assert set(n.query(downstream=0, gather_upstream=True, barrier=8)) == \
+    assert n.gather_segnums(downstream=18, gather_upstream=True) == []
+    assert set(n.gather_segnums(
+        downstream=0, gather_upstream=True, barrier=8)) == \
         {1, 2, 3, 4, 5, 6, 8}
     with pytest.raises(
             IndexError,
             match=r'downstream segnum \-1 not found in segments\.index'):
-        n.query(downstream=-1)
+        n.gather_segnums(downstream=-1)
 
 
 def test_aggregate_fluss_headwater(fluss_n):

--- a/tests/test_modflow.py
+++ b/tests/test_modflow.py
@@ -1138,7 +1138,7 @@ def test_coastal_reduced(coastal_lines_gdf, coastal_flow_m, tmp_path):
     # Modify swn object
     n.remove(
         condition=n.segments["stream_order"] == 1,
-        segnums=n.query(upstream=3047927))
+        segnums=n.gather_segnums(upstream=3047927))
     assert len(n) == 130
     # Load a MODFLOW model
     m = flopy.modflow.Modflow.load(

--- a/tests/test_modflow6.py
+++ b/tests/test_modflow6.py
@@ -644,7 +644,7 @@ def test_coastal_reduced(
     # Modify swn object
     n.remove(
         condition=n.segments["stream_order"] == 1,
-        segnums=n.query(upstream=3047927))
+        segnums=n.gather_segnums(upstream=3047927))
     assert len(n) == 130
     # Load a MODFLOW model
     sim = flopy.mf6.MFSimulation.load(

--- a/tests/test_modflow_base.py
+++ b/tests/test_modflow_base.py
@@ -573,7 +573,7 @@ def test_coastal_reduced(coastal_lines_gdf):
     # Modify swn object
     n.remove(
         condition=n.segments["stream_order"] == 1,
-        segnums=n.query(upstream=3047927))
+        segnums=n.gather_segnums(upstream=3047927))
     assert len(n) == 130
     # Load a MODFLOW model
     m = flopy.modflow.Modflow.load(


### PR DESCRIPTION
This renames the method `query` to `gather_segnums`, because it has a more clear name.

Also, make the method keyword-only, and add examples.