### PR TITLE
Implement diversions for MODFLOW6

### DIFF
--- a/docs/source/swnmf6.rst
+++ b/docs/source/swnmf6.rst
@@ -33,6 +33,23 @@ Reach data generation
    SwnMf6.set_reach_data_from_segments
    SwnMf6.set_reach_slope
 
+Streamflow Routing Package
+--------------------------
+.. autosummary::
+   :toctree: ref/
+
+   SwnMf6.set_sfr_obj
+   SwnMf6.default_packagedata
+   SwnMf6.packagedata_frame
+   SwnMf6.write_packagedata
+   SwnMf6.flopy_packagedata
+   SwnMf6.connectiondata_series
+   SwnMf6.write_connectiondata
+   SwnMf6.flopy_connectiondata
+   SwnMf6.diversions_frame
+   SwnMf6.write_diversions
+   SwnMf6.flopy_diversions
+
 Utilities
 ---------
 .. autosummary::

--- a/swn/file.py
+++ b/swn/file.py
@@ -117,6 +117,8 @@ colname10 = {
     "dist_to_segnum": "dst_to_seg",
     "dist_to_seg": "dst_to_seg",
     "is_within_catchment": "within_cat",
+    "div_from_rno": "divfromrno",
+    "div_to_rnos": "divtornos",
 }
 assert all(len(x) <= 10 for x in colname10.values())
 

--- a/swn/modflow/_swnmodflow.py
+++ b/swn/modflow/_swnmodflow.py
@@ -123,14 +123,6 @@ class SwnModflow(SwnModflowBase):
             swn=swn, model=model, domain_action=ibound_action,
             reach_include_fraction=reach_include_fraction)
 
-        # Add more information to reaches
-        obj.reaches.index.name = "reachID"
-        obj.reaches["rchlen"] = obj.reaches.geometry.length
-        sel = obj.reaches["rchlen"] == 0
-        if sel.any():
-            # zero lengths not permitted
-            obj.reaches.loc[sel, "rchlen"] = 1.0
-
         return obj
 
     def __repr__(self):
@@ -150,8 +142,8 @@ class SwnModflow(SwnModflowBase):
         reaches = self.reaches
         if reaches is not None:
             s += "  {} in reaches ({}): {}\n".format(
-                len(self.reaches), self.reaches.index.name,
-                abbr_str(list(self.reaches.index), 4))
+                len(reaches), reaches.index.name,
+                abbr_str(list(reaches.index), 4))
         segment_data = self.segment_data
         if segment_data is not None:
             s += "  {} in segment_data ({}): {}\n".format(


### PR DESCRIPTION
- New method adds more columns to reaches and diversions
- Add `diversions_frame` method
- Add `write_diversions` method
- Add `flopy_diversions` method
- Add optional "mask" attribute for reaches, which have cellid NONE
- Fix cellid NONE for `flopy_packagedata`

Other changes
- Move reach length and index name logic to SwnModflowBase
- Set ustrf to 0.0 for headwater reaches