### PR TITLE
Mark deprecation for swn.spatial.get_sindex; require geopandas >=0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Python 3.7+ is required.
 
 ### Required
 
- - `geopandas` - process spatial data similar to pandas
+ - `geopandas >=0.9` - process spatial data similar to pandas
  - `packaging` - used to check package versions
  - `pandas >=1.2` - tabular data analysis
  - `pyproj >=2.2` - spatial projection support

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "geopandas",
+    "geopandas >=0.9",
     "packaging",
     "pandas >=1.2",
     "pyproj >=2.2",

--- a/swn/core.py
+++ b/swn/core.py
@@ -14,7 +14,7 @@ import pandas as pd
 from shapely.geometry import LineString, Point
 
 from .compat import ignore_shapely_warnings_for_object_array
-from .spatial import bias_substring, get_sindex
+from .spatial import bias_substring
 from .util import abbr_str
 
 

--- a/swn/modflow/_base.py
+++ b/swn/modflow/_base.py
@@ -11,7 +11,7 @@ from shapely.ops import linemerge, substring
 
 from ..compat import ignore_shapely_warnings_for_object_array
 from ..core import SurfaceWaterNetwork
-from ..spatial import bias_substring, compare_crs, get_sindex, visible_wkt
+from ..spatial import bias_substring, compare_crs, visible_wkt
 from ..util import is_location_frame
 from ._misc import tile_series_as_frame, transform_data_to_series_or_frame
 

--- a/swn/spatial.py
+++ b/swn/spatial.py
@@ -1,7 +1,7 @@
 """Spatial methods."""
 
 __all__ = [
-    "get_sindex", "interp_2d_to_3d",
+    "interp_2d_to_3d",
     "wkt_to_dataframe", "wkt_to_geodataframe", "wkt_to_geoseries",
     "force_2d", "round_coords", "compare_crs", "get_crs",
     "bias_substring",
@@ -38,8 +38,10 @@ rtree_threshold = 100
 def get_sindex(gdf):
     """Get or build an R-Tree spatial index.
 
-    Particularly useful for geopandas<0.2.0;>0.7.0;0.9.0
+    .. deprecated:: 0.6
+        This method is no longer used.
     """
+    warn("get_sindex is no longer used", DeprecationWarning, stacklevel=2)
     sindex = None
     if (hasattr(gdf, '_rtree_sindex')):
         return getattr(gdf, '_rtree_sindex')

--- a/tests/test_spatial.py
+++ b/tests/test_spatial.py
@@ -18,8 +18,10 @@ def test_get_sindex():
         geometry=geopandas.points_from_xy(
             range(spatial.rtree_threshold), range(spatial.rtree_threshold)))
     if spatial.rtree:
-        assert spatial.get_sindex(xy) is not None
-        assert spatial.get_sindex(xy.geometry) is not None
+        with pytest.deprecated_call():
+            assert spatial.get_sindex(xy) is not None
+        with pytest.deprecated_call():
+            assert spatial.get_sindex(xy.geometry) is not None
 
 
 def test_interp_2d_to_3d():


### PR DESCRIPTION
This approach might have been useful for older geopandas versions, but not anymore. The performance of `gdf.sindex` to get/generate a spatial index is good.

Also, require geopandas >=0.9