### PR TITLE
Use items instead of iteritems

### DIFF
--- a/swn/core.py
+++ b/swn/core.py
@@ -243,7 +243,7 @@ class SurfaceWaterNetwork:
 
         # A few checks
         sel = to_segnum_l.apply(len) > 1
-        for segnum1, to_segnums in to_segnum_l.loc[sel].iteritems():
+        for segnum1, to_segnums in to_segnum_l.loc[sel].items():
             m = ('segment %s has more than one downstream segments: %s',
                  segnum1, str(to_segnums))
             obj.logger.error(*m)
@@ -1141,7 +1141,7 @@ class SurfaceWaterNetwork:
                 res.loc[match.gidx, "segnum"] = match.segnum.values
                 res.loc[match.gidx, "method"] = "nearest"
             else:  # slower method
-                for gidx, g in geom[sel].iteritems():
+                for gidx, g in geom[sel].items():
                     dists = segments_gs.distance(g).sort_values()
                     segnums = dists.index[dists.iloc[0] == dists]
                     if len(segnums) == 1:
@@ -1609,14 +1609,14 @@ class SurfaceWaterNetwork:
             to_segnums = self.to_segnums
             df.loc[to_segnums.index, c2] = df.loc[to_segnums, c1].values
         elif method == "additive":
-            for segnum, from_segnums in self.from_segnums.iteritems():
+            for segnum, from_segnums in self.from_segnums.items():
                 if len(from_segnums) <= 1:
                     continue
                 # get proportions of upstream values
                 from_value1 = df.loc[sorted(from_segnums), c1]
                 from_value1_prop = from_value1 / from_value1.sum()
                 from_value2 = df.loc[segnum, c1] * from_value1_prop
-                for from_segnum, v2 in from_value2.iteritems():
+                for from_segnum, v2 in from_value2.items():
                     df.loc[from_segnum, c2] = v2
         elif method == "constant":
             pass
@@ -1664,7 +1664,7 @@ class SurfaceWaterNetwork:
         #   [dx, elev], where dx is 2D distance from upstream coord
         #   elev is the adjusted elevation
         profile_d = {}  # key is segnum, value is list of profile tuples
-        for segnum, geom in self.segments.geometry.iteritems():
+        for segnum, geom in self.segments.geometry.items():
             coords = geom.coords[:]  # coordinates
             x0, y0, z0 = coords[0]  # upstream coordinate
             profile = [[0.0, z0]]

--- a/swn/file.py
+++ b/swn/file.py
@@ -150,7 +150,7 @@ def gdf_to_shapefile(gdf, shp_fname, **kwargs):
     geom_name = gdf.geometry.name
 
     # Change data types, as necessary
-    for col, dtype in gdf.dtypes.iteritems():
+    for col, dtype in gdf.dtypes.items():
         if col == geom_name:
             continue
         if dtype == object:

--- a/swn/modflow/_base.py
+++ b/swn/modflow/_base.py
@@ -392,7 +392,7 @@ class SwnModflowBase:
         xv = modelgrid.xvertices
         yv = modelgrid.yvertices
         i, j = (np.array(s[1])
-                for s in grid_df.reset_index()[["i", "j"]].iteritems())
+                for s in grid_df.reset_index()[["i", "j"]].items())
         cell_verts = zip(
             zip(xv[i, j], yv[i, j]),
             zip(xv[i, j + 1], yv[i, j + 1]),
@@ -855,7 +855,7 @@ class SwnModflowBase:
             diversions["in_model"] = True
             outside_model = []
             segnum_s = set(reaches.segnum)
-            for divid, from_segnum in diversions.from_segnum.iteritems():
+            for divid, from_segnum in diversions.from_segnum.items():
                 if from_segnum not in segnum_s:
                     # segnum does not exist -- segment is outside model
                     outside_model.append(divid)
@@ -947,7 +947,7 @@ class SwnModflowBase:
         reaches["ireach"] = 0
         iseg = ireach = 0
         prev_segnum = None
-        for idx, segnum in reaches.segnum.iteritems():
+        for idx, segnum in reaches.segnum.items():
             is_diversion = has_diversions and reaches.at[idx, "diversion"]
             if is_diversion:
                 if uses_segments:

--- a/swn/modflow/_misc.py
+++ b/swn/modflow/_misc.py
@@ -151,7 +151,7 @@ def transform_data_to_series_or_frame(
         do_astype = True
         if isinstance(data, dict):
             try:
-                series = pd.Series(data, dtype=dtype)
+                series = pd.Series(data).astype(dtype)
                 do_astype = False
             except ValueError:
                 data = pd.Series(data)

--- a/swn/modflow/_swnmf6.py
+++ b/swn/modflow/_swnmf6.py
@@ -120,9 +120,9 @@ class SwnMf6(SwnModflowBase):
         obj.reaches["to_rno"] = -1
         if has_diversions:
             segnum_iter = obj.reaches.loc[
-                ~obj.reaches.diversion, "segnum"].iteritems()
+                ~obj.reaches.diversion, "segnum"].items()
         else:
-            segnum_iter = obj.reaches["segnum"].iteritems()
+            segnum_iter = obj.reaches["segnum"].items()
         rno, segnum = next(segnum_iter)
         for next_rno, next_segnum in segnum_iter:
             obj.reaches.at[rno, "to_rno"] = get_to_rno()
@@ -156,7 +156,7 @@ class SwnMf6(SwnModflowBase):
             obj.diversions.loc[div_sel, "idv"] = 1
             rno_counts = obj.diversions[div_sel].groupby(
                 "rno").count()["in_model"]
-            for rno, count in rno_counts[rno_counts > 1].iteritems():
+            for rno, count in rno_counts[rno_counts > 1].items():
                 obj.diversions.loc[obj.diversions["rno"] == rno, "idv"] = \
                     obj.diversions.idv[obj.diversions["rno"] == rno].cumsum()
             # cross-reference iconr to rno used as a reach
@@ -544,7 +544,7 @@ class SwnMf6(SwnModflowBase):
         cn = cn.apply(lambda x: " ".join(str(v).rjust(rnolen) for v in x))
         with open(fname, "w") as f:
             f.write(f"# rno {' '.join(icn)}\n")
-            for rno, ic in cn.iteritems():
+            for rno, ic in cn.items():
                 f.write(rowfmt.format(rno, ic))
 
     def flopy_connectiondata(self):

--- a/swn/modflow/_swnmodflow.py
+++ b/swn/modflow/_swnmodflow.py
@@ -831,7 +831,7 @@ class SwnModflow(SwnModflowBase):
             swn.pair_segments_frame(
                 width1, width_out, name="width", method="constant")
         ], axis=1, copy=False)
-        for name, series in more_segment_columns.iteritems():
+        for name, series in more_segment_columns.items():
             self.segments[name] = series
         self.segments["roughch"] = swn.segments_series(roughch)
 
@@ -1633,7 +1633,7 @@ class SwnModflow(SwnModflowBase):
             "segnum", verify_integrity=True).iseg
 
         to_reachids = {}
-        for segnum, iseg in segnum_iseg.iteritems():
+        for segnum, iseg in segnum_iseg.items():
             sel = self.reaches.index[self.reaches.iseg == iseg]
             to_reachids.update(dict(zip(sel[0:-1], sel[1:])))
             next_segnum = self.segments.to_segnum[segnum]

--- a/swn/spatial.py
+++ b/swn/spatial.py
@@ -353,7 +353,7 @@ def find_location_pairs(loc_df, n):
     loc_df.sort_values(["sequence", "seg_ndist"], inplace=True)
     # Start from upstream locations, querying downstream, except last
     pairs = set()
-    for upstream_idx, upstream_segnum in loc_df.segnum.iloc[:-1].iteritems():
+    for upstream_idx, upstream_segnum in loc_df.segnum.iloc[:-1].items():
         downstream_idx = None
         # First case that the downstream segnum is in the same segnum
         next_loc = loc_df.iloc[loc_df.index.get_loc(upstream_idx) + 1]


### PR DESCRIPTION
`iteritems()` is deprecated since version 1.5.0, so use `items()` instead.

Also `pd.Series(data, dtype=dtype)` does not properly cast a dict to dtype, so use `pd.Series(data).astype(dtype)` instead.