### PR TITLE
Feat: write_formatted_frame and read_formatted_frame methods

### DIFF
--- a/docs/source/swnmf6.rst
+++ b/docs/source/swnmf6.rst
@@ -57,3 +57,5 @@ Utilities
 
     SwnMf6.get_location_frame_reach_info
     SwnMf6.route_reaches
+    read_formatted_frame
+    write_formatted_frame

--- a/swn/modflow/__init__.py
+++ b/swn/modflow/__init__.py
@@ -1,6 +1,16 @@
 """MODFLOW module for a surface water network."""
 from ._misc import geotransform_from_flopy
-from ._swnmf6 import SwnMf6
+from ._swnmf6 import (
+    SwnMf6,
+    read_formatted_frame,
+    write_formatted_frame,
+)
 from ._swnmodflow import SwnModflow
 
-__all__ = ["SwnModflow", "SwnMf6", "geotransform_from_flopy"]
+__all__ = [
+    "SwnModflow",
+    "SwnMf6",
+    "geotransform_from_flopy",
+    "read_formatted_frame",
+    "write_formatted_frame",
+]

--- a/swn/modflow/_swnmf6.py
+++ b/swn/modflow/_swnmf6.py
@@ -1,6 +1,10 @@
 """Interface for flopy's implementation for MODFLOW 6."""
 
-__all__ = ["SwnMf6"]
+__all__ = [
+    "SwnMf6",
+    "read_formatted_frame",
+    "write_formatted_frame",
+]
 
 from itertools import zip_longest
 
@@ -444,25 +448,14 @@ class SwnMf6(SwnModflowBase):
         -------
         None
 
+        See Also
+        --------
+        read_formatted_frame : Read formatted file as a pandas DataFrame.
+
         """
         pn = self.packagedata_frame(
             "native", auxiliary=auxiliary, boundname=boundname)
-        pn.index.name = "# rno"
-        formatters = None
-        if "boundname" in pn.columns:
-            # Add single quotes for any items with spaces
-            sel = pn.boundname.str.contains(" ")
-            if sel.any():
-                pn.loc[sel, "boundname"] = pn.loc[sel, "boundname"].map(
-                    lambda x: f"'{x}'")
-            # left-justify column
-            formatters = {
-                "boundname":
-                    f"{{:<{pn['boundname'].str.len().max()}s}}".format}
-        with open(fname, "w") as f:
-            pn.reset_index().to_string(
-                f, header=True, index=False, formatters=formatters)
-            f.write("\n")
+        write_formatted_frame(pn, fname)
 
     def flopy_packagedata(self, auxiliary: list = [], boundname=None):
         """Return list of lists for flopy.
@@ -656,19 +649,13 @@ class SwnMf6(SwnModflowBase):
         ----------
         fname : str
             Output file name.
+
+        See Also
+        --------
+        read_formatted_frame : Read formatted file as a pandas DataFrame.
         """
         dat = self.diversions_frame("native")
-        if len(dat) == 0:
-            with open(fname, "w") as f:
-                f.write("# " + " ".join(dat.columns) + "\n")
-            return
-        dat.rename(columns={"rno": "# rno"}, inplace=True)
-        # left-justify cprior
-        cprior_len = dat["cprior"].str.len().max()
-        formatters = {"cprior": f"{{:<{cprior_len}s}}".format}
-        with open(fname, "w") as f:
-            dat.to_string(f, header=True, index=False, formatters=formatters)
-            f.write("\n")
+        write_formatted_frame(dat, fname, index=False)
 
     def flopy_diversions(self):
         """Return list of lists for flopy.
@@ -1664,8 +1651,204 @@ class SwnMf6(SwnModflowBase):
                 idx2 = con2.index(rno)
         return con1[:idx1] + list(reversed(con2[:idx2]))
 
+
 def _flopy_set3darray(flopyobj, array3d):
     data = [{"filename": flopyobj[k].fname, "data":ar}
             if flopyobj[k].fname else {"data": ar}
             for k, ar in enumerate(array3d)]
     flopyobj.set_data(data)
+
+
+def read_formatted_frame(fname):
+    r"""Write a data frame as a free formatted table.
+
+    Parameters
+    ----------
+    fname : Path, str or file-like object
+        Path to read file.
+    comment_header : bool, default True
+        If True, first line starts with '#' to make it a comment, otherwise
+        it will be an uncommented header.
+
+    Returns
+    -------
+    pandas.DataFrame
+
+    See Also
+    --------
+    write_formatted_frame
+
+    Examples
+    --------
+    >>> from io import StringIO
+    >>> import pandas as pd
+    >>> from swn.modflow import read_formatted_frame
+    >>> f = StringIO('''\
+    ... # rno        value1  value2  value3
+    ... 1     -1.000000e+10       1  'first one'
+    ... 12    -1.000000e-10      10   two
+    ... 33     0.000000e+00     100   three
+    ... 40     1.000000e-10    1000
+    ... 450    1.000000e+00   10000   five
+    ... 6267   1.000000e+03  100000   six
+    ... ''')
+    >>> df = read_formatted_frame(f).set_index("rno")
+    >>> print(df)
+                value1  value2     value3
+    rno                                  
+    1    -1.000000e+10       1  first one
+    12   -1.000000e-10      10        two
+    33    0.000000e+00     100      three
+    40    1.000000e-10    1000        NaN
+    450   1.000000e+00   10000       five
+    6267  1.000000e+03  100000        six
+    """  # noqa
+    fname_is_filelike = hasattr(fname, "readline")
+    try:
+        if fname_is_filelike:
+            f = fname
+        else:
+            f = open(fname)
+        headers = f.readline().lstrip("#").strip().split()
+        try:
+            df = pd.read_csv(f, sep=r"\s+", quotechar="'", header=None)
+            df.columns = headers
+        except pd.errors.EmptyDataError:
+            df = pd.DataFrame(columns=headers)
+    finally:
+        if not fname_is_filelike:
+            f.close()
+    return df
+
+
+def write_formatted_frame(df, fname, index=True, comment_header=True):
+    """Write a data frame as a free formatted table.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        DataFrame to write.
+    fname : Path, str or file-like object
+        Path to write file.
+    index : bool, default True
+        Write row names (index).
+    comment_header : bool, default True
+        If True, first line starts with '#' to make it a comment, otherwise
+        it will be an uncommented header.
+
+    See Also
+    --------
+    read_formatted_frame
+
+    Examples
+    --------
+    >>> from io import StringIO
+    >>> import pandas as pd
+    >>> from swn.modflow import write_formatted_frame
+    >>> df = pd.DataFrame({
+    ...     "value1": [-1e10, -1e-10, 0, 1e-10, 1, 1000],
+    ...     "value2": [1, 10, 100, 1000, 10000, 100000],
+    ...     "value3": ["first one", "two", "three", None, "five", "six"],
+    ...     }, index=[1, 12, 33, 40, 450, 6267])
+    >>> df.index.name = "rno"
+    >>> print(df)
+                value1  value2     value3
+    rno                                  
+    1    -1.000000e+10       1  first one
+    12   -1.000000e-10      10        two
+    33    0.000000e+00     100      three
+    40    1.000000e-10    1000       None
+    450   1.000000e+00   10000       five
+    6267  1.000000e+03  100000        six
+    >>> f = StringIO()
+    >>> write_formatted_frame(df, f)
+    >>> _ = f.seek(0)
+    >>> print(f.read(), end="")
+    # rno        value1  value2  value3
+    1     -1.000000e+10       1  'first one'
+    12    -1.000000e-10      10   two
+    33     0.000000e+00     100   three
+    40     1.000000e-10    1000
+    450    1.000000e+00   10000   five
+    6267   1.000000e+03  100000   six
+    """  # noqa
+    if not isinstance(df, pd.DataFrame):
+        raise TypeError("expected df to be a pandas.DataFrame")
+    fname_is_filelike = hasattr(fname, "write")
+
+    if len(df) == 0:
+        # Special case with no rows
+        line = "# " if comment_header else ""
+        if index:
+            line += (df.index.name or "index") + " "
+        line += (" ".join(df.columns)) + "\n"
+        try:
+            if fname_is_filelike:
+                f = fname
+            else:
+                f = open(fname, "w")
+            f.write(line)
+        finally:
+            if not fname_is_filelike:
+                f.close()
+        return
+
+    df = df.copy()
+    if comment_header:
+        if index:
+            if df.index.name is None:
+                df.index.name = "index"
+            elif not df.index.name.startswith("#"):
+                df.index.name = "# " + df.index.name
+        else:
+            first = df.columns[0]
+            df.rename(columns={first: "#" + first}, inplace=True)
+    formatters = {}
+    # scan for str type columns
+    for name in list(df.columns):
+        # add single quotes around items with space chars
+        try:
+            sel = df[name].str.contains(" ").fillna(False)
+        except AttributeError:
+            continue
+        na = df[name].isna()
+        if sel.any():
+            df.loc[sel, name] = df.loc[sel, name].map(lambda x: f"'{x}'")
+            df.loc[~sel, name] = df.loc[~sel, name].map(lambda x: f" {x} ")
+        else:
+            df[name] = df[name].astype(str)
+        if na.any():
+            df.loc[na, name] = ""
+        # left-justify column
+        ljust = max(df[name].str.len().max(), len(name))
+        if len(name) < ljust:
+            df.rename(columns={name: name.ljust(ljust)}, inplace=True)
+            name = name.ljust(ljust)
+        formatters[name] = f"{{:<{ljust}s}}".format
+    # format the table to string
+    out = df.to_string(header=True, index=index, formatters=formatters)
+    lines = out.split("\n")
+    if index:
+        # combine the first two lines
+        line = lines[1].rstrip()
+        lines[0] = line + lines.pop(0)[len(line):]
+    elif comment_header:
+        # Move '#' to start of line
+        line = lines[0]
+        pos = line.index("#")
+        if pos > 0:
+            llist = list(line)
+            llist[pos] = " "
+            llist[0] = "#"
+            line = "".join(llist)
+            lines[0] = line
+    try:
+        if fname_is_filelike:
+            f = fname
+        else:
+            f = open(fname, "w")
+        for line in lines:
+            f.write(line.rstrip() + "\n")
+    finally:
+        if not fname_is_filelike:
+            f.close()


### PR DESCRIPTION
Closes #59 for packagedata and diversions files, but does not change connectiondata (for now, at least)

Also, add read_formatted_frame as a convenience to read these formats back into a pandas DataFrame.