### PR TITLE
Feature: Add functionality to allow other MF6 packages to use reaches data

### DIFF
--- a/docs/source/swnmf6.rst
+++ b/docs/source/swnmf6.rst
@@ -38,7 +38,6 @@ Streamflow Routing Package
 .. autosummary::
    :toctree: ref/
 
-   SwnMf6.set_sfr_obj
    SwnMf6.default_packagedata
    SwnMf6.packagedata_frame
    SwnMf6.write_packagedata
@@ -49,6 +48,17 @@ Streamflow Routing Package
    SwnMf6.diversions_frame
    SwnMf6.write_diversions
    SwnMf6.flopy_diversions
+   SwnMf6.set_sfr_obj
+
+Other packages
+--------------
+.. autosummary::
+   :toctree: ref/
+
+   SwnMf6.set_package_obj
+   SwnMf6.package_period_frame
+   SwnMf6.write_package_period
+   SwnMf6.flopy_package_period
 
 Utilities
 ---------

--- a/swn/modflow/_base.py
+++ b/swn/modflow/_base.py
@@ -286,7 +286,7 @@ class SwnModflowBase:
                     "model must be a flopy.mf6.MFModel object; found " +
                     str(type(model)))
             sim = model.simulation
-            if "tdis" not in sim.package_key_dict.keys():
+            if "tdis" not in sim.package_type_dict.keys():
                 raise ValueError("TDIS package required")
             if "dis" not in model.package_type_dict.keys():
                 raise ValueError("DIS package required")


### PR DESCRIPTION
This allows other packages (e.g. DRAIN) to be created using data in the reaches dataframe, including auxiliary and auxmultname options.

#### New functions:
 - package_period_frame() - returns a DataFrame
 - write_package_period() - writes a period file
 - flopy_package_period() - format for flopy
 - set_package_obj() - sets flopy model for new package

#### Also:
 - change return type of set_sfr_obj() to return flopy package