### PR TITLE
Move read_formatted_frame() and write_formatted_frame()

### DIFF
--- a/docs/source/file.rst
+++ b/docs/source/file.rst
@@ -9,6 +9,7 @@ Methods
 .. autosummary::
    :toctree: ref/
 
-   topnet2ts
-   gdf_to_shapefile
-
+    topnet2ts
+    gdf_to_shapefile
+    read_formatted_frame
+    write_formatted_frame

--- a/docs/source/swnmf6.rst
+++ b/docs/source/swnmf6.rst
@@ -67,5 +67,3 @@ Utilities
 
     SwnMf6.get_location_frame_reach_info
     SwnMf6.route_reaches
-    read_formatted_frame
-    write_formatted_frame

--- a/swn/file.py
+++ b/swn/file.py
@@ -1,6 +1,11 @@
 """File reading/writing helpers."""
 
-__all__ = ["topnet2ts", "gdf_to_shapefile"]
+__all__ = [
+    "topnet2ts",
+    "gdf_to_shapefile",
+    "read_formatted_frame",
+    "write_formatted_frame",
+]
 
 import geopandas
 import pandas as pd
@@ -166,3 +171,198 @@ def gdf_to_shapefile(gdf, shp_fname, **kwargs):
             rename[key] = value
     gdf.rename(columns=rename).reset_index(drop=False)\
         .to_file(str(shp_fname), **kwargs)
+
+
+def read_formatted_frame(fname):
+    r"""Write a data frame as a free formatted table.
+
+    Parameters
+    ----------
+    fname : Path, str or file-like object
+        Path to read file.
+    comment_header : bool, default True
+        If True, first line starts with '#' to make it a comment, otherwise
+        it will be an uncommented header.
+
+    Returns
+    -------
+    pandas.DataFrame
+
+    See Also
+    --------
+    write_formatted_frame
+
+    Examples
+    --------
+    >>> from io import StringIO
+    >>> import pandas as pd
+    >>> from swn.file import read_formatted_frame
+    >>> f = StringIO('''\
+    ... # rno        value1  value2  value3
+    ... 1     -1.000000e+10       1  'first one'
+    ... 12    -1.000000e-10      10   two
+    ... 33     0.000000e+00     100   three
+    ... 40     1.000000e-10    1000
+    ... 450    1.000000e+00   10000   five
+    ... 6267   1.000000e+03  100000   six
+    ... ''')
+    >>> df = read_formatted_frame(f).set_index("rno")
+    >>> print(df)
+                value1  value2     value3
+    rno                                  
+    1    -1.000000e+10       1  first one
+    12   -1.000000e-10      10        two
+    33    0.000000e+00     100      three
+    40    1.000000e-10    1000        NaN
+    450   1.000000e+00   10000       five
+    6267  1.000000e+03  100000        six
+    """  # noqa
+    fname_is_filelike = hasattr(fname, "readline")
+    try:
+        if fname_is_filelike:
+            f = fname
+        else:
+            f = open(fname)
+        headers = f.readline().lstrip("#").strip().split()
+        try:
+            df = pd.read_csv(f, sep=r"\s+", quotechar="'", header=None)
+            df.columns = headers
+        except pd.errors.EmptyDataError:
+            df = pd.DataFrame(columns=headers)
+    finally:
+        if not fname_is_filelike:
+            f.close()
+    return df
+
+
+def write_formatted_frame(df, fname, index=True, comment_header=True):
+    """Write a data frame as a free formatted table.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        DataFrame to write.
+    fname : str, path-like or file-like object
+        Path to write file.
+    index : bool, default True
+        Write row names (index).
+    comment_header : bool, default True
+        If True, first line starts with '#' to make it a comment, otherwise
+        it will be an uncommented header.
+
+    See Also
+    --------
+    read_formatted_frame
+
+    Examples
+    --------
+    >>> from io import StringIO
+    >>> import pandas as pd
+    >>> from swn.file import write_formatted_frame
+    >>> df = pd.DataFrame({
+    ...     "value1": [-1e10, -1e-10, 0, 1e-10, 1, 1000],
+    ...     "value2": [1, 10, 100, 1000, 10000, 100000],
+    ...     "value3": ["first one", "two", "three", None, "five", "six"],
+    ...     }, index=[1, 12, 33, 40, 450, 6267])
+    >>> df.index.name = "rno"
+    >>> print(df)
+                value1  value2     value3
+    rno                                  
+    1    -1.000000e+10       1  first one
+    12   -1.000000e-10      10        two
+    33    0.000000e+00     100      three
+    40    1.000000e-10    1000       None
+    450   1.000000e+00   10000       five
+    6267  1.000000e+03  100000        six
+    >>> f = StringIO()
+    >>> write_formatted_frame(df, f)
+    >>> _ = f.seek(0)
+    >>> print(f.read(), end="")
+    # rno        value1  value2  value3
+    1     -1.000000e+10       1  'first one'
+    12    -1.000000e-10      10   two
+    33     0.000000e+00     100   three
+    40     1.000000e-10    1000
+    450    1.000000e+00   10000   five
+    6267   1.000000e+03  100000   six
+    """  # noqa
+    if not isinstance(df, pd.DataFrame):
+        raise TypeError("expected df to be a pandas.DataFrame")
+    fname_is_filelike = hasattr(fname, "write")
+
+    if len(df) == 0:
+        # Special case with no rows
+        line = "# " if comment_header else ""
+        if index:
+            line += (df.index.name or "index") + " "
+        line += (" ".join(df.columns)) + "\n"
+        try:
+            if fname_is_filelike:
+                f = fname
+            else:
+                f = open(fname, "w")
+            f.write(line)
+        finally:
+            if not fname_is_filelike:
+                f.close()
+        return
+
+    df = df.copy()
+    if comment_header:
+        if index:
+            if df.index.name is None:
+                df.index.name = "index"
+            elif not df.index.name.startswith("#"):
+                df.index.name = "# " + df.index.name
+        else:
+            first = df.columns[0]
+            df.rename(columns={first: "#" + first}, inplace=True)
+    formatters = {}
+    # scan for str type columns
+    for name in list(df.columns):
+        # add single quotes around items with space chars
+        try:
+            sel = df[name].str.contains(" ").fillna(False)
+        except AttributeError:
+            continue
+        na = df[name].isna()
+        if sel.any():
+            df.loc[sel, name] = df.loc[sel, name].map(lambda x: f"'{x}'")
+            df.loc[~sel, name] = df.loc[~sel, name].map(lambda x: f" {x} ")
+        else:
+            df[name] = df[name].astype(str)
+        if na.any():
+            df.loc[na, name] = ""
+        # left-justify column
+        ljust = max(df[name].str.len().max(), len(name))
+        if len(name) < ljust:
+            df.rename(columns={name: name.ljust(ljust)}, inplace=True)
+            name = name.ljust(ljust)
+        formatters[name] = f"{{:<{ljust}s}}".format
+    # format the table to string
+    out = df.to_string(header=True, index=index, formatters=formatters)
+    lines = out.split("\n")
+    if index:
+        # combine the first two lines
+        line = lines[1].rstrip()
+        lines[0] = line + lines.pop(0)[len(line):]
+    elif comment_header:
+        # Move '#' to start of line
+        line = lines[0]
+        pos = line.index("#")
+        if pos > 0:
+            llist = list(line)
+            llist[pos] = " "
+            llist[0] = "#"
+            line = "".join(llist)
+            lines[0] = line
+    try:
+        if fname_is_filelike:
+            f = fname
+        else:
+            f = open(fname, "w")
+        for line in lines:
+            f.write(line.rstrip() + "\n")
+    finally:
+        if not fname_is_filelike:
+            f.close()

--- a/swn/modflow/__init__.py
+++ b/swn/modflow/__init__.py
@@ -1,16 +1,10 @@
 """MODFLOW module for a surface water network."""
 from ._misc import geotransform_from_flopy
-from ._swnmf6 import (
-    SwnMf6,
-    read_formatted_frame,
-    write_formatted_frame,
-)
+from ._swnmf6 import SwnMf6
 from ._swnmodflow import SwnModflow
 
 __all__ = [
     "SwnModflow",
     "SwnMf6",
     "geotransform_from_flopy",
-    "read_formatted_frame",
-    "write_formatted_frame",
 ]

--- a/tests/test_modflow6.py
+++ b/tests/test_modflow6.py
@@ -1118,13 +1118,13 @@ def test_diversions(tmp_path):
         df[col] = df[col].astype(int)
     pd.testing.assert_frame_equal(
         df,
-        swn.modflow.read_formatted_frame(
+        swn.file.read_formatted_frame(
             tmp_path / "packagedata.dat").set_index("rno"),
         check_dtype=check_dtype,
     )
     pd.testing.assert_frame_equal(
         nm.diversions_frame("native").reset_index(drop=True),
-        swn.modflow.read_formatted_frame(
+        swn.file.read_formatted_frame(
             tmp_path / "diversions.dat")
     )
 
@@ -1244,90 +1244,6 @@ def test_route_reaches():
     with pytest.raises(ConnectionError, match="reach networks are disjoint"):
         nm.route_reaches(1, 6, allow_indirect=True)
     # TODO: diversions?
-
-
-def test_read_write_formatted_frame(tmp_path):
-    df = pd.DataFrame({
-        "value1": [-1e10, -1e-10, 0, 1e-10, 1, 1000],
-        "value2": [1, 10, 100, 1000, 10000, 100000],
-        "value3": ["first one", "two", "three", np.nan, "five", "six"],
-        }, index=[1, 12, 33, 40, 450, 6267])
-    df.index.name = "rno"
-
-    # test default write method
-    fname = tmp_path / "file.dat"
-    swn.modflow.write_formatted_frame(df, fname)
-    # check first line
-    with fname.open() as f:
-        header = f.readline()
-    assert header == "# rno        value1  value2  value3\n"
-
-    # test read method
-    df2 = swn.modflow.read_formatted_frame(fname).set_index("rno")
-    pd.testing.assert_frame_equal(df, df2)
-
-    # similar checks without comment char
-    swn.modflow.write_formatted_frame(df, fname, comment_header=False)
-    # check first line
-    with fname.open() as f:
-        header = f.readline()
-    assert header == "rno         value1  value2  value3\n"
-
-    # test read method
-    df2 = swn.modflow.read_formatted_frame(fname).set_index("rno")
-    pd.testing.assert_frame_equal(df, df2)
-
-    # without index
-    swn.modflow.write_formatted_frame(
-        df, fname, comment_header=True, index=False)
-    # check first line
-    with fname.open() as f:
-        header = f.readline()
-    assert header == "#      value1  value2 value3\n"
-
-    # test read method
-    df2 = swn.modflow.read_formatted_frame(fname)
-    pd.testing.assert_frame_equal(df.reset_index(drop=True), df2)
-
-    swn.modflow.write_formatted_frame(
-        df, fname, comment_header=False, index=False)
-    # check first line
-    with fname.open() as f:
-        header = f.readline()
-    assert header == "       value1  value2 value3\n"
-
-    # test read method
-    df2 = swn.modflow.read_formatted_frame(fname)
-    pd.testing.assert_frame_equal(df.reset_index(drop=True), df2)
-
-    # empty data frame
-    df = df.iloc[0:0]
-    swn.modflow.write_formatted_frame(df, fname)
-    assert fname.read_text() == "# rno value1 value2 value3\n"
-    df2 = swn.modflow.read_formatted_frame(fname).set_index("rno")
-    pd.testing.assert_frame_equal(
-        df, df2, check_index_type=False, check_dtype=False)
-
-    swn.modflow.write_formatted_frame(df, fname, index=False)
-    assert fname.read_text() == "# value1 value2 value3\n"
-    df2 = swn.modflow.read_formatted_frame(fname)
-    pd.testing.assert_frame_equal(
-        df.reset_index(drop=True), df2,
-        check_index_type=False, check_dtype=False)
-
-    swn.modflow.write_formatted_frame(df, fname, comment_header=False)
-    assert fname.read_text() == "rno value1 value2 value3\n"
-    df2 = swn.modflow.read_formatted_frame(fname).set_index("rno")
-    pd.testing.assert_frame_equal(
-        df, df2, check_index_type=False, check_dtype=False)
-
-    swn.modflow.write_formatted_frame(
-        df, fname, comment_header=False, index=False)
-    assert fname.read_text() == "value1 value2 value3\n"
-    df2 = swn.modflow.read_formatted_frame(fname)
-    pd.testing.assert_frame_equal(
-        df.reset_index(drop=True), df2,
-        check_index_type=False, check_dtype=False)
 
 
 def test_get_flopy_mf6_package():


### PR DESCRIPTION
This PR moves `read_formatted_frame()` and `write_formatted_frame()` from `swn.modflow` to `swn.file`, which is more appropriate.