### PR TITLE
Use flopy's set_data() method again, assuming version 3.3.6 or later

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ doc = [
     "sphinx-issues",
 ]
 extra = [
-    "flopy",
+    "flopy >=3.3.6",
     "matplotlib",
     "netcdf4",
 ]

--- a/swn/modflow/_swnmf6.py
+++ b/swn/modflow/_swnmf6.py
@@ -1351,10 +1351,7 @@ class SwnMf6(SwnModflowBase):
                     "%s cells less than %s", thincells.sum(), minthick)
                 laythick[thincells] = minthick
                 layerbots[k + 1] = layerbots[k] - laythick
-            # flopy messing with external file names so apply in wrapper
-            # TODO remove line if flopy is patched (https://github.com/modflowpy/flopy/issues/1534)
-            _flopy_set3darray(self.model.dis.botm, layerbots)
-            # self.model.dis.botm.set_data(layerbots)
+            self.model.dis.botm.set_data(layerbots)
 
     def _reachbyreach_elevs(
             self, minslope=1e-4, minincise=0.2, minthick=0.5, fix_dis=True,
@@ -1644,10 +1641,7 @@ class SwnMf6(SwnModflowBase):
                     "%s cells less than %s", thincells.sum(), minthick)
                 laythick[thincells] = minthick
                 layerbots[k + 1] = layerbots[k] - laythick
-            # flopy messing with external file names so apply in wrapper
-            # TODO remove line if flopy is patched (https://github.com/modflowpy/flopy/issues/1534)
-            _flopy_set3darray(self.model.dis.botm, layerbots)
-            # self.model.dis.botm.set_data(layerbots)
+            self.model.dis.botm.set_data(layerbots)
 
 
     def _to_rno_elevs(
@@ -1958,13 +1952,6 @@ class SwnMf6(SwnModflowBase):
                 idx1 = tmp1
                 idx2 = con2.index(rno)
         return con1[:idx1] + list(reversed(con2[:idx2]))
-
-
-def _flopy_set3darray(flopyobj, array3d):
-    data = [{"filename": flopyobj[k].fname, "data":ar}
-            if flopyobj[k].fname else {"data": ar}
-            for k, ar in enumerate(array3d)]
-    flopyobj.set_data(data)
 
 
 def get_flopy_mf6_package(name: str):


### PR DESCRIPTION
This undoes #60 since `set_data()` is fixed for external files since FloPy version 3.3.6