### PR TITLE
Accommodate different reach index names for future flopy versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,8 +48,9 @@ jobs:
         run: |
           pytest -v swn --doctest-modules
 
-      - name: Run tests with older packages
+      - name: Run tests with develop flopy and other older packages
         run: |
+          pip install https://github.com/modflowpy/flopy/archive/refs/heads/develop.zip
           pip install "shapely<2.0" "pandas<2.0"
           pytest -v -n2 --cov --cov-append
 


### PR DESCRIPTION
Future flopy / MODFLOW 6 versions have renamed the reach index name from "rno" to "ifno". This PR adapts to these changes from flopy.

Data frame column names like "to_rno" also may be renamed "to_ifno".

Internally, this is called "ridx" for reach index.