### PR TITLE
Maintenance updates for recent pandas and FloPy releases

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, '3.11']
+        # pick lower and upper versions only
+        python-version: ["3.8", "3.12"]
 
     steps:
       - uses: actions/checkout@v3
@@ -48,10 +49,9 @@ jobs:
         run: |
           pytest -v swn --doctest-modules
 
-      - name: Run tests with develop flopy and other older packages
+      - name: Run tests with older flopy and other packages
         run: |
-          pip install https://github.com/modflowpy/flopy/archive/refs/heads/develop.zip
-          pip install "shapely<2.0" "pandas<2.0"
+          pip install "flopy<3.5" "pandas<2.0" "shapely<2.0"
           pytest -v -n2 --cov --cov-append
 
       - name: Upload coverage reports to Codecov

--- a/swn/core.py
+++ b/swn/core.py
@@ -1780,6 +1780,7 @@ class SurfaceWaterNetwork:
             to_segnums = self.to_segnums
             df.loc[to_segnums.index, c2] = df.loc[to_segnums, c1].values
         elif method == "additive":
+            df = df.astype(float)
             for segnum, from_segnums in self.from_segnums.items():
                 if len(from_segnums) <= 1:
                     continue

--- a/swn/core.py
+++ b/swn/core.py
@@ -352,7 +352,9 @@ class SurfaceWaterNetwork:
         obj.segments["from_segnums"] = from_segnums
         sel = obj.segments.from_segnums.isna()
         if sel.any():
-            obj.segments.loc[sel, "from_segnums"] = [set() for _ in range(sel.sum())]
+            obj.segments.loc[sel, "from_segnums"] = pd.Series(
+                [set() for _ in range(sel.sum())], index=sel[sel].index
+            )
         obj.logger.debug(
             "evaluating segments upstream from %d outlet%s",
             len(outlets),
@@ -746,7 +748,7 @@ class SurfaceWaterNetwork:
         )
         series.index.name = self.segments.index.name
         series.name = "from_segnums"
-        return series
+        return series.astype(object)
 
     def route_segnums(self, start, end, *, allow_indirect=False):
         r"""Return a list of segnums that connect a pair of segnums.

--- a/swn/core.py
+++ b/swn/core.py
@@ -1804,7 +1804,7 @@ class SurfaceWaterNetwork:
                 raise ValueError("expected value_out to be scalar, dict or Series")
             if not set(value_out.index).issubset(set(df.index)):
                 raise ValueError("value_out.index is not a subset of segments.index")
-            df.loc[value_out.index, c2] = value_out
+            df.loc[value_out.index, c2] = value_out.astype(value.dtype)
         return df
 
     def adjust_elevation_profile(self, min_slope=1.0 / 1000):

--- a/swn/file.py
+++ b/swn/file.py
@@ -126,6 +126,8 @@ colname10 = {
     "is_within_catchment": "within_cat",
     "div_from_rno": "divfromrno",
     "div_to_rnos": "divtornos",
+    "div_from_ifno": "divfromfno",
+    "div_to_ifnos": "divtofnos",
 }
 assert all(len(x) <= 10 for x in colname10.values())
 
@@ -204,22 +206,22 @@ def read_formatted_frame(fname):
     >>> import pandas as pd
     >>> from swn.file import read_formatted_frame
     >>> f = StringIO('''\
-    ... # rno        value1  value2  value3
-    ... 1     -1.000000e+10       1  'first one'
-    ... 12    -1.000000e-10      10   two
-    ... 33     0.000000e+00     100   three
-    ... 40     1.000000e-10    1000
-    ... 450    1.000000e+00   10000   five
-    ... 6267   1.000000e+03  100000   six
+    ... # ifno        value1  value2  value3
+    ... 1      -1.000000e+10       1  'first one'
+    ... 12     -1.000000e-10      10   two
+    ... 33      0.000000e+00     100   three
+    ... 40      1.000000e-10    1000
+    ... 450     1.000000e+00   10000   five
+    ... 6267    1.000000e+03  100000   six
     ... ''')
-    >>> df = read_formatted_frame(f).set_index("rno")
+    >>> df = read_formatted_frame(f).set_index("ifno")
     >>> print(df)
                 value1  value2     value3
-    rno                                  
+    ifno                                  
     1    -1.000000e+10       1  first one
     12   -1.000000e-10      10        two
     33    0.000000e+00     100      three
-    40    1.000000e-10    1000        NaN
+    40    1.000000e-10    1000       None
     450   1.000000e+00   10000       five
     6267  1.000000e+03  100000        six
     """  # noqa
@@ -286,27 +288,27 @@ def write_formatted_frame(df, fname, index=True, comment_header=True):
     ...     "value2": [1, 10, 100, 1000, 10000, 100000],
     ...     "value3": ["first one", "two", "three", None, "five", "six"],
     ...     }, index=[1, 12, 33, 40, 450, 6267])
-    >>> df.index.name = "rno"
+    >>> df.index.name = "ifno"
     >>> print(df)
-                value1  value2     value3
-    rno
-    1    -1.000000e+10       1  first one
-    12   -1.000000e-10      10        two
-    33    0.000000e+00     100      three
-    40    1.000000e-10    1000       None
-    450   1.000000e+00   10000       five
-    6267  1.000000e+03  100000        six
+                 value1  value2     value3
+    ifno
+    1     -1.000000e+10       1  first one
+    12    -1.000000e-10      10        two
+    33     0.000000e+00     100      three
+    40     1.000000e-10    1000       None
+    450    1.000000e+00   10000       five
+    6267   1.000000e+03  100000        six
     >>> f = StringIO()
     >>> write_formatted_frame(df, f)
     >>> _ = f.seek(0)
     >>> print(f.read(), end="")
-    # rno        value1  value2  value3
-    1     -1.000000e+10       1  'first one'
-    12    -1.000000e-10      10   two
-    33     0.000000e+00     100   three
-    40     1.000000e-10    1000
-    450    1.000000e+00   10000   five
-    6267   1.000000e+03  100000   six
+    # ifno        value1  value2  value3
+    1      -1.000000e+10       1  'first one'
+    12     -1.000000e-10      10   two
+    33      0.000000e+00     100   three
+    40      1.000000e-10    1000
+    450     1.000000e+00   10000   five
+    6267    1.000000e+03  100000   six
     """  # noqa
     if not isinstance(df, pd.DataFrame):
         raise TypeError("expected df to be a pandas.DataFrame")

--- a/swn/file.py
+++ b/swn/file.py
@@ -249,6 +249,11 @@ def read_formatted_frame(fname):
     finally:
         if not fname_is_filelike:
             f.close()
+    # Ensure that object type (including str) use None for missing instead of NaN
+    for name, dtype in df.dtypes.items():
+        if np.issubdtype(dtype, object):
+            sel = df[name].isna()
+            df.loc[sel, name] = None
     return df
 
 

--- a/swn/modflow/_base.py
+++ b/swn/modflow/_base.py
@@ -1241,9 +1241,9 @@ class SwnModflowBase:
         elif method in ("grid_top", "rch_len"):
             # Estimate slope from top and grid spacing
             dis = self.model.dis
-            col_size = np.median(dis.delr.array)
-            row_size = np.median(dis.delc.array)
-            px, py = np.gradient(dis.top.array, col_size, row_size)
+            col_size = np.median(dis.delr.array).astype(np.float64)
+            row_size = np.median(dis.delc.array).astype(np.float64)
+            px, py = np.gradient(dis.top.array.astype(np.float64), col_size, row_size)
             if method == "grid_top":
                 grid_slope = np.sqrt(px**2 + py**2)
                 self.set_reach_data_from_array(grid_name, grid_slope)

--- a/swn/modflow/_base.py
+++ b/swn/modflow/_base.py
@@ -1390,9 +1390,9 @@ class SwnModflowBase:
         >>> loc_df = n.locate_geoms(obs_gs)
         >>> r_df = nm.get_location_frame_reach_info(loc_df)
         >>> r_df
-            rno  k  i  j  iseg  ireach  dist_to_reach
-        10    3  0  1  1     1       3       1.664101
-        11    7  0  2  1     3       2       2.000000
+            ifno  k  i  j  iseg  ireach  dist_to_reach
+        10     3  0  1  1     1       3       1.664101
+        11     7  0  2  1     3       2       2.000000
         >>> loc_reach_df = pd.concat([loc_df, r_df], axis=1)
         """  # noqa
         loc_df = loc_df.copy()

--- a/swn/modflow/_base.py
+++ b/swn/modflow/_base.py
@@ -1096,6 +1096,9 @@ class SwnModflowBase:
             self.logger.debug(
                 "set_reach_data_from_segments: choosing method=%r", method
             )
+        if method == "continuous":
+            if not np.issubdtype(value.dtype, np.floating):
+                value = value.astype(float)
         segdat = self._swn.pair_segments_frame(value, value_out, method=method)
         c1, c2 = segdat.columns
         res = self.reaches[["segnum"]].join(segdat[c1], on="segnum")

--- a/swn/modflow/_swnmf6.py
+++ b/swn/modflow/_swnmf6.py
@@ -418,7 +418,7 @@ class SwnMf6(SwnModflowBase):
         >>> nm.reaches["aux1"] = 2.0 + nm.reaches.index / 10.0
         >>> nm.packagedata_frame("native", auxiliary="aux1")
              k  i  j       rlen  rwid   rgrd  ...    man  ncon  ustrf  ndv  aux1  boundname
-        rno                                   ...
+        ifno                                  ...
         1    1  1  1  18.027756  10.0  0.001  ...  0.024     1    0.0    0   2.1        101
         2    1  1  2   6.009252  10.0  0.001  ...  0.024     2    1.0    0   2.2        101
         3    1  2  2  12.018504  10.0  0.001  ...  0.024     2    1.0    0   2.3        101
@@ -428,16 +428,16 @@ class SwnMf6(SwnModflowBase):
         7    1  3  2  10.000000  10.0  0.001  ...  0.024     1    1.0    0   2.7        100
         <BLANKLINE>
         [7 rows x 15 columns]
-        >>> nm.packagedata_frame("flopy", boundname=False)
-                cellid       rlen  rwid   rgrd  rtp  rbth  rhk    man  ncon  ustrf  ndv
-        rno
-        0    (0, 0, 0)  18.027756  10.0  0.001  1.0   1.0  1.0  0.024     1    0.0    0
-        1    (0, 0, 1)   6.009252  10.0  0.001  1.0   1.0  1.0  0.024     2    1.0    0
-        2    (0, 1, 1)  12.018504  10.0  0.001  1.0   1.0  1.0  0.024     2    1.0    0
-        3    (0, 0, 1)  21.081851  10.0  0.001  1.0   1.0  1.0  0.024     1    0.0    0
-        4    (0, 1, 1)  10.540926  10.0  0.001  1.0   1.0  1.0  0.024     2    1.0    0
-        5    (0, 1, 1)  10.000000  10.0  0.001  1.0   1.0  1.0  0.024     3    1.0    0
-        6    (0, 2, 1)  10.000000  10.0  0.001  1.0   1.0  1.0  0.024     1    1.0    0
+        >>> nm.packagedata_frame("flopy", boundname=False).drop(columns="man")
+                 cellid       rlen  rwid   rgrd  rtp  rbth  rhk  ncon  ustrf  ndv
+        ifno
+        0     (0, 0, 0)  18.027756  10.0  0.001  1.0   1.0  1.0     1    0.0    0
+        1     (0, 0, 1)   6.009252  10.0  0.001  1.0   1.0  1.0     2    1.0    0
+        2     (0, 1, 1)  12.018504  10.0  0.001  1.0   1.0  1.0     2    1.0    0
+        3     (0, 0, 1)  21.081851  10.0  0.001  1.0   1.0  1.0     1    0.0    0
+        4     (0, 1, 1)  10.540926  10.0  0.001  1.0   1.0  1.0     2    1.0    0
+        5     (0, 1, 1)  10.000000  10.0  0.001  1.0   1.0  1.0     3    1.0    0
+        6     (0, 2, 1)  10.000000  10.0  0.001  1.0   1.0  1.0     1    1.0    0
         """  # noqa
         from flopy.mf6 import ModflowGwfsfr as Mf6Sfr
 
@@ -645,17 +645,17 @@ class SwnMf6(SwnModflowBase):
         ...     length_units="meters", xorigin=30.0, yorigin=70.0)
         >>> nm = swn.SwnMf6.from_swn_flopy(n, gwf)
         >>> nm.diversions_frame("native")
-            rno  idv  iconr cprior
-        11    3    1      8   upto
-        12    5    1      9   upto
-        13    6    1     10   upto
-        14    6    2     11   upto
+            ifno  idv  iconr cprior
+        11    3     1      8   upto
+        12    5     1      9   upto
+        13    6     1     10   upto
+        14    6     2     11   upto
         >>> nm.diversions_frame("flopy")
-            rno  idv  iconr cprior
-        11    2    0      7   upto
-        12    4    0      8   upto
-        13    5    0      9   upto
-        14    5    1     10   upto
+            ifno  idv  iconr cprior
+        11     2    0      7   upto
+        12     4    0      8   upto
+        13     5    0      9   upto
+        14     5    1     10   upto
         """  # noqa
         from flopy.mf6 import ModflowGwfsfr as Mf6Sfr
 
@@ -781,7 +781,7 @@ class SwnMf6(SwnModflowBase):
         >>> nm.reaches["boundname"] = nm.reaches["segnum"]
         >>> nm.package_period_frame("drn", "native", auxiliary="dlen")
                  k  i  j  elev        cond       dlen boundname
-        per rno
+        per ifno
         1   1    1  1  1  10.0  180.277564  18.027756       101
             2    1  1  2  10.0   60.092521   6.009252       101
             3    1  2  2  10.0  120.185043  12.018504       101
@@ -791,7 +791,7 @@ class SwnMf6(SwnModflowBase):
             7    1  3  2  10.0  100.000000  10.000000       100
         >>> nm.package_period_frame("drn","flopy", boundname=False)
                     cellid  elev        cond
-        per rno
+        per ifno
         0   0    (0, 0, 0)  10.0  180.277564
             1    (0, 0, 1)  10.0   60.092521
             2    (0, 1, 1)  10.0  120.185043
@@ -1985,21 +1985,21 @@ class SwnMf6(SwnModflowBase):
         ...     gwf, nrow=3, ncol=2, delr=20.0, delc=20.0, idomain=1,
         ...     length_units="meters", xorigin=30.0, yorigin=70.0)
         >>> nm = swn.SwnMf6.from_swn_flopy(n, gwf)
-        >>> nm.reaches[["iseg", "ireach", "to_rno", "from_rnos", "segnum"]]
-             iseg  ireach  to_rno from_rnos  segnum
-        rno
-        1       1       1       2        {}     101
-        2       1       2       3       {1}     101
-        3       1       3       6       {2}     101
-        4       2       1       5        {}     102
-        5       2       2       6       {4}     102
-        6       3       1       7    {3, 5}     100
-        7       3       2       0       {6}     100
+        >>> nm.reaches[["iseg", "ireach", "to_ifno", "from_ifnos", "segnum"]]
+             iseg  ireach  to_ifno from_ifnos  segnum
+        ifno
+        1       1       1        2         {}     101
+        2       1       2        3        {1}     101
+        3       1       3        6        {2}     101
+        4       2       1        5         {}     102
+        5       2       2        6        {4}     102
+        6       3       1        7     {3, 5}     100
+        7       3       2        0        {6}     100
         >>> nm.route_reaches(1, 7)
         [1, 2, 3, 6, 7]
         >>> nm.reaches.loc[nm.route_reaches(1, 7), ["i", "j", "rlen"]]
              i  j       rlen
-        rno
+        ifno
         1    0  0  18.027756
         2    0  1   6.009252
         3    1  1  12.018504

--- a/swn/modflow/_swnmodflow.py
+++ b/swn/modflow/_swnmodflow.py
@@ -1168,7 +1168,9 @@ class SwnModflow(SwnModflowBase):
             else:
                 dn = down
         # this returns a DF once the apply is done!
-        return pd.Series({"nseg": seg.name, "elevdn": dn, "outseg_elevup": outseg_up})
+        return pd.Series(
+            {"nseg": seg.name, "elevdn": dn, "outseg_elevup": outseg_up}, dtype=object
+        )
 
     def set_forward_segs(self, min_slope=1e-4):
         """Set minimum slope in forwards direction.
@@ -1207,10 +1209,12 @@ class SwnModflow(SwnModflowBase):
             ednsel = tmp[tmp["elevdn"].notna()].index
             oeupsel = tmp[tmp["outseg_elevup"].notna()].index
             # set elevdn and outseg_elevup
-            self.segment_data.loc[ednsel, "elevdn"] = tmp.loc[ednsel, "elevdn"]
+            self.segment_data.loc[ednsel, "elevdn"] = tmp.loc[ednsel, "elevdn"].astype(
+                self.segment_data.elevdn.dtype
+            )
             self.segment_data.loc[oeupsel, "outseg_elevup"] = tmp.loc[
                 oeupsel, "outseg_elevup"
-            ]
+            ].astype(self.segment_data.outseg_elevup.dtype)
             # get `elevups` for outflow segs from `outseg_elevups`
             # taking `min` ensures outseg elevup is below all inflow elevdns
             tmp2 = self.segment_data.apply(self.set_outseg_elev_for_seg, axis=1).min(

--- a/swn/modflow/_swnmodflow.py
+++ b/swn/modflow/_swnmodflow.py
@@ -891,7 +891,9 @@ class SwnModflow(SwnModflowBase):
         if "zcoord_avg" in self.reaches.columns:
             # Created by set_reach_slope(); be aware of NaN
             nn = ~self.reaches.zcoord_avg.isnull()
-            self.reaches.loc[nn, "strtop"] = self.reaches.loc[nn, "zcoord_avg"]
+            self.reaches.loc[nn, "strtop"] = self.reaches.loc[nn, "zcoord_avg"].astype(
+                self.reaches.strtop.dtype
+            )
 
         has_diversions = self.diversions is not None
         # Assume all streams will use ICALC=1

--- a/swn/modflow/_swnmodflow.py
+++ b/swn/modflow/_swnmodflow.py
@@ -979,7 +979,7 @@ class SwnModflow(SwnModflowBase):
         )
         # seg bottoms
         btmidx = (
-            self.reaches.groupby("iseg")["ireach"].transform(max)
+            self.reaches.groupby("iseg")["ireach"].transform("max")
             == self.reaches["ireach"]
         )
         kij_df = self.reaches[btmidx][["iseg", "k", "i", "j"]].sort_values("iseg")

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -921,11 +921,11 @@ def test_pair_segments_frame(valid_n):
     # additive
     pd.testing.assert_frame_equal(
         n.pair_segments_frame(1, method="additive"),
-        pd.DataFrame({1: [1, 1, 1], 2: [1.0, 0.5, 0.5]}),
+        pd.DataFrame({1: [1.0, 1.0, 1.0], 2: [1.0, 0.5, 0.5]}),
     )
     pd.testing.assert_frame_equal(
         n.pair_segments_frame(1, {0: 2, 1: 10}, name="foo", method="additive"),
-        pd.DataFrame({"foo1": [1, 1, 1], "foo2": [2.0, 10.0, 0.5]}),
+        pd.DataFrame({"foo1": [1.0, 1.0, 1.0], "foo2": [2.0, 10.0, 0.5]}),
     )
     pd.testing.assert_frame_equal(
         n.pair_segments_frame([10.0, 2.0, 3.0], name="foo", method="additive"),

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -120,7 +120,7 @@ def test_read_write_formatted_frame(tmp_path):
         {
             "value1": [-1e10, -1e-10, 0, 1e-10, 1, 1000],
             "value2": [1, 10, 100, 1000, 10000, 100000],
-            "value3": ["first one", "two", "three", np.nan, "five", "six"],
+            "value3": ["first one", "two", "three", None, "five", "six"],
         },
         index=[1, 12, 33, 40, 450, 6267],
     )

--- a/tests/test_modflow_base.py
+++ b/tests/test_modflow_base.py
@@ -326,11 +326,26 @@ def test_set_reach_data_from_segments():
             index=reach_idx,
         ),
     )
+    expected_width = pd.Series(
+        [
+            1.897650,
+            2.072998,
+            2.204509,
+            1.912058,
+            2.197152,
+            4.219137,
+            8.073046,
+        ],
+        name="width",
+        index=reach_idx,
+    )
+    nm.set_reach_data_from_segments("width", n.segments.width, 10.0)
+    pd.testing.assert_series_equal(nm.reaches["width"], expected_width)
+    nm.set_reach_data_from_segments("width", n.segments.width, "10")
+    pd.testing.assert_series_equal(nm.reaches["width"], expected_width)
     # misc errors
     with pytest.raises(ValueError, match="name must be a str type"):
         nm.set_reach_data_from_segments(1, 2)
-    with pytest.raises(TypeError, match="unsupported operand type"):
-        nm.set_reach_data_from_segments("width", n.segments.width, "10")
 
 
 @pytest.mark.parametrize("has_diversions", [False, True], ids=["nodiv", "div"])


### PR DESCRIPTION
The pandas issues were discovered using the warning filter `error::FutureWarning`.

The big change from flopy is that "rno" (reach number) is now "ifno" (integer feature number), so use this for the docstrings.