### PR TITLE
Feature: add `SwnMf6.gather_reaches()`

### DIFF
--- a/docs/source/swnmf6.rst
+++ b/docs/source/swnmf6.rst
@@ -66,4 +66,5 @@ Utilities
    :toctree: ref/
 
     SwnMf6.get_location_frame_reach_info
+    SwnMf6.gather_reaches
     SwnMf6.route_reaches

--- a/swn/file.py
+++ b/swn/file.py
@@ -177,7 +177,7 @@ def gdf_to_shapefile(gdf, shp_fname, **kwargs):
             rename[col] = colname10[col]
     if rename:
         gdf.rename(columns=rename, inplace=True)
-    gdf.to_file(str(shp_fname), **kwargs)
+    gdf.to_file(str(shp_fname), index=True, **kwargs)
 
 
 def read_formatted_frame(fname):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import geopandas
 import pandas as pd
 import pytest
+from shapely import wkt
 
 try:
     import matplotlib
@@ -27,6 +28,28 @@ from swn.compat import ignore_shapely_warnings_for_object_array
 PANDAS_VESRSION_TUPLE = tuple(int(x) for x in re.findall(r"\d+", pd.__version__))
 
 datadir = Path("tests") / "data"
+
+
+# https://commons.wikimedia.org/wiki/File:Flussordnung_(Strahler).svg
+fluss_gs = geopandas.GeoSeries(
+    wkt.loads(
+        """\
+MULTILINESTRING(
+    (380 490, 370 420), (300 460, 370 420), (370 420, 420 330),
+    (190 250, 280 270), (225 180, 280 270), (280 270, 420 330),
+    (420 330, 584 250), (520 220, 584 250), (584 250, 710 160),
+    (740 270, 710 160), (735 350, 740 270), (880 320, 740 270),
+    (925 370, 880 320), (974 300, 880 320), (760 460, 735 350),
+    (650 430, 735 350), (710 160, 770 100), (700  90, 770 100),
+    (770 100, 820  40))
+"""
+    ).geoms
+)
+
+
+@pytest.fixture
+def fluss_n():
+    return swn.SurfaceWaterNetwork.from_lines(fluss_gs)
 
 
 @pytest.fixture(scope="session", autouse=True)


### PR DESCRIPTION
This feature is similar to [`SurfaceWaterNetwork.gather_segnums`](https://mwtoews.github.io/surface-water-network/ref/swn.SurfaceWaterNetwork.gather_segnums.html), but is only for SwnMf6.

There are not any plans to make `SwnModflow.gather_reaches()` unless there is demand.

Some other unrelated minor changes:

- Ensure `gdf_to_shapefile` always writes the index
- Relocate `fluss_n` pytest fixture
- Rename test variables `m` for model to `gwf` for groundwater flow model, as per usual convention