### PR TITLE
Always use native Python types for list outputs

### DIFF
--- a/swn/modflow/_base.py
+++ b/swn/modflow/_base.py
@@ -939,7 +939,9 @@ class SwnModflowBase:
                     has_sjoin_nearest = False
             for divn in diversions_in_model.itertuples():
                 # Use the last upstream reach as a template for a new reach
-                reach_d = dict(reaches.loc[reaches.segnum == divn.from_segnum].iloc[-1])
+                reach_d = (
+                    reaches.loc[reaches.segnum == divn.from_segnum].iloc[-1].to_dict()
+                )
                 reach_d.update(
                     {
                         "segnum": swn.END_SEGNUM,

--- a/swn/modflow/_swnmf6.py
+++ b/swn/modflow/_swnmf6.py
@@ -2020,12 +2020,14 @@ class SwnMf6(SwnModflowBase):
         if start == end:
             return [start]
         to_ridxname = f"to_{self.reach_index_name}"
-        to_ridxs = dict(self.reaches.loc[self.reaches[to_ridxname] != 0, to_ridxname])
+        to_ridxs_d = self.reaches.loc[
+            self.reaches[to_ridxname] != 0, to_ridxname
+        ].to_dict()
 
         def go_downstream(ridx):
             yield ridx
-            if ridx in to_ridxs:
-                yield from go_downstream(to_ridxs[ridx])
+            if ridx in to_ridxs_d:
+                yield from go_downstream(to_ridxs_d[ridx])
 
         con1 = list(go_downstream(start))
         try:
@@ -2145,19 +2147,21 @@ class SwnMf6(SwnModflowBase):
 
         def go_downstream(ridx):
             yield ridx
-            if ridx in to_ridxs:
-                yield from go_downstream(to_ridxs[ridx])
+            if ridx in to_ridxs_d:
+                yield from go_downstream(to_ridxs_d[ridx])
 
         to_ridx_name = f"to_{self.reach_index_name}"
-        to_ridxs = dict(self.reaches.loc[self.reaches[to_ridx_name] != 0, to_ridx_name])
+        to_ridxs_d = self.reaches.loc[
+            self.reaches[to_ridx_name] != 0, to_ridx_name
+        ].to_dict()
         from_ridxs = self.reaches[f"from_{self.reach_index_name}s"]
         # Note that `.copy(deep=True)` does not work; use deepcopy
         from_ridxs = from_ridxs[from_ridxs.apply(len) > 0].apply(deepcopy)
         for barrier in check_and_return_list(barrier, "barrier"):
             for ridx in from_ridxs.get(barrier, []):
-                del to_ridxs[ridx]
-            from_ridxs[to_ridxs[barrier]].remove(barrier)
-            del to_ridxs[barrier]
+                del to_ridxs_d[ridx]
+            from_ridxs[to_ridxs_d[barrier]].remove(barrier)
+            del to_ridxs_d[barrier]
 
         ridxs = []
         for ridx in check_and_return_list(upstream, "upstream"):

--- a/swn/modflow/_swnmodflow.py
+++ b/swn/modflow/_swnmodflow.py
@@ -1747,19 +1747,21 @@ class SwnModflow(SwnModflowBase):
             .iseg
         )
 
-        to_reachids = {}
+        to_reachids_d = {}
         for segnum, iseg in segnum_iseg.items():
-            sel = self.reaches.index[self.reaches.iseg == iseg]
-            to_reachids.update(dict(zip(sel[0:-1], sel[1:])))
+            sel_l = self.reaches.index[self.reaches.iseg == iseg].to_list()
+            to_reachids_d.update(dict(zip(sel_l[0:-1], sel_l[1:])))
             next_segnum = self.segments.to_segnum[segnum]
-            next_reachids = self.reaches.index[self.reaches.segnum == next_segnum]
-            if len(next_reachids) > 0:
-                to_reachids[sel[-1]] = next_reachids[0]
+            next_reachids_l = self.reaches.index[
+                self.reaches.segnum == next_segnum
+            ].to_list()
+            if len(next_reachids_l) > 0:
+                to_reachids_d[sel_l[-1]] = next_reachids_l[0]
 
         def go_downstream(rid):
             yield rid
-            if rid in to_reachids:
-                yield from go_downstream(to_reachids[rid])
+            if rid in to_reachids_d:
+                yield from go_downstream(to_reachids_d[rid])
 
         con1 = list(go_downstream(start))
         try:

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -56,7 +56,7 @@ def test_init(coastal_swn, coastal_lines_gdf):
     assert list(nto[nto == 32].index) == [3050413, 3050418]
     cat_group = n.segments.groupby("cat_group").count()["to_segnum"]
     assert len(cat_group) == 3
-    assert dict(cat_group) == {3046700: 1, 3046737: 173, 3046736: 130}
+    assert cat_group.to_dict() == {3046700: 1, 3046737: 173, 3046736: 130}
     ln = n.segments["dist_to_outlet"]
     np.testing.assert_almost_equal(ln.min(), 42.437, 3)
     np.testing.assert_almost_equal(ln.mean(), 11105.741, 3)
@@ -69,7 +69,7 @@ def test_init(coastal_swn, coastal_lines_gdf):
     assert list(n.segments["sequence"])[-6:] == [156, 4, 155, 1, 3, 2]
     stream_order = n.segments.groupby("stream_order").count()["to_segnum"]
     assert len(stream_order) == 5
-    assert dict(stream_order) == {1: 154, 2: 72, 3: 46, 4: 28, 5: 4}
+    assert stream_order.to_dict() == {1: 154, 2: 72, 3: 46, 4: 28, 5: 4}
     np.testing.assert_array_equal(
         n.segments["stream_order"], coastal_lines_gdf["StreamOrde"]
     )

--- a/tests/test_spatial.py
+++ b/tests/test_spatial.py
@@ -109,14 +109,14 @@ def test_wkt_to_dataframe():
     with pytest.deprecated_call():
         df = spatial.wkt_to_dataframe(valid_lines_list)
     assert df.shape == (3, 1)
-    assert dict(df.dtypes) == {"geometry": np.dtype("O")}
+    assert df.dtypes.to_dict() == {"geometry": np.dtype("O")}
     assert type(df) == pd.DataFrame
     pd.testing.assert_index_equal(df.index, pd.RangeIndex(3))
 
     with pytest.deprecated_call():
         df = spatial.wkt_to_dataframe(valid_lines_list, "other")
     assert df.shape == (3, 1)
-    assert dict(df.dtypes) == {"other": np.dtype("O")}
+    assert df.dtypes.to_dict() == {"other": np.dtype("O")}
     assert type(df) == pd.DataFrame
     pd.testing.assert_index_equal(df.index, pd.RangeIndex(3))
 


### PR DESCRIPTION
These differences were only noticed with NumPy 2.0, but have always been present.

Demo:
```
In [1]: import pandas as pd

In [2]: s = pd.Series([1, 2])

In [3]: dict(s)
Out[3]: {0: np.int64(1), 1: np.int64(2)}

In [4]: s.to_dict()
Out[4]: {0: 1, 1: 2}
```