### PR TITLE
Show warning if lines and polygons don't spatially intersect

### DIFF
--- a/src/swn/core.py
+++ b/src/swn/core.py
@@ -216,6 +216,15 @@ class SurfaceWaterNetwork:
             raise ValueError("lines must all be LineString types")
         # Create a new GeoDataFrame with a copy of line's geometry
         segments = geopandas.GeoDataFrame(geometry=lines)
+        if segments.index.min() > 0:
+            END_SEGNUM = 0
+        else:
+            END_SEGNUM = segments.index.min() - 1
+        segments["to_segnum"] = END_SEGNUM
+        obj = cls(segments=segments, END_SEGNUM=END_SEGNUM)
+        obj.errors = []
+        obj.warnings = []
+        del segments, END_SEGNUM  # dereference local copies
         if not (polygons is None or isinstance(polygons, geopandas.GeoSeries)):
             raise ValueError("polygons must be a GeoSeries or None")
         if polygons is not None:
@@ -224,15 +233,17 @@ class SurfaceWaterNetwork:
                 or not (polygons.index == lines.index).all()
             ):
                 raise ValueError("polygons.index is different than lines.index")
-        if segments.index.min() > 0:
-            END_SEGNUM = 0
-        else:
-            END_SEGNUM = segments.index.min() - 1
-        segments["to_segnum"] = END_SEGNUM
-        obj = cls(segments=segments, END_SEGNUM=END_SEGNUM)
-        del segments, END_SEGNUM  # dereference local copies
-        obj.errors = []
-        obj.warnings = []
+            no_intersects = ~lines.intersects(polygons, align=True)
+            if no_intersects.all():
+                obj.logger.error("lines and catchments don't intersect")
+            elif no_intersects.any():
+                obj.logger.error(
+                    "lines and catchments partially intersect: "
+                    "%d of %d lines (%.1f%%) don't intersect their catchment",
+                    no_intersects.sum(),
+                    no_intersects.size,
+                    no_intersects.sum() * 100.0 / no_intersects.size,
+                )
         obj.logger.debug("creating start/end points and spatial join objects")
         start_pts = obj.segments.interpolate(0.0, normalized=True)
         end_pts = obj.segments.interpolate(1.0, normalized=True)

--- a/src/swn/core.py
+++ b/src/swn/core.py
@@ -222,17 +222,24 @@ class SurfaceWaterNetwork:
             END_SEGNUM = segments.index.min() - 1
         segments["to_segnum"] = END_SEGNUM
         obj = cls(segments=segments, END_SEGNUM=END_SEGNUM)
+        del segments, END_SEGNUM  # dereference local copies
         obj.errors = []
         obj.warnings = []
-        del segments, END_SEGNUM  # dereference local copies
-        if not (polygons is None or isinstance(polygons, geopandas.GeoSeries)):
-            raise ValueError("polygons must be a GeoSeries or None")
         if polygons is not None:
+            if not isinstance(polygons, geopandas.GeoSeries):
+                raise ValueError("polygons must be a GeoSeries or None")
+            if not set(polygons.geom_type.unique()).issubset(
+                ["Polygon", "MultiPolygon"]
+            ):
+                raise ValueError(
+                    "polygons geometry type must be Polygon and/or MultiPolygon"
+                )
             if (
                 len(polygons.index) != len(lines.index)
                 or not (polygons.index == lines.index).all()
             ):
                 raise ValueError("polygons.index is different than lines.index")
+
             no_intersects = ~lines.intersects(polygons, align=True)
             if no_intersects.all():
                 obj.logger.error("lines and catchments don't intersect")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,7 @@ def coastal_lines_gdf():
 @pytest.fixture(scope="module")
 def coastal_polygons_gdf(coastal_lines_gdf):
     polygons = geopandas.read_file(datadir / "DN2_Coastal_strahler1_vf.shp")
+    crs = polygons.crs
     polygons.set_index("nzsegment", inplace=True)
     # repair the shapefile by filling in the missing data
     for segnum in [3046737, 3047026, 3047906, 3048995, 3049065]:
@@ -81,6 +82,7 @@ def coastal_polygons_gdf(coastal_lines_gdf):
         }
         with ignore_shapely_warnings_for_object_array():
             polygons.loc[segnum] = poly_d
+        polygons.crs = crs  # restore original CRS after edit
     return polygons.reindex(index=coastal_lines_gdf.index)
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -574,9 +574,17 @@ def test_init_polygons():
     if matplotlib:
         _ = n.plot()
         plt.close()
-    # check error
+    # check errors
     with pytest.raises(ValueError, match="polygons must be a GeoSeries or None"):
         swn.SurfaceWaterNetwork.from_lines(valid_lines, 1.0)
+    with pytest.raises(
+        ValueError, match="polygons.index is different than lines.index"
+    ):
+        swn.SurfaceWaterNetwork.from_lines(
+            valid_lines, valid_polygons.sort_index(ascending=False)
+        )
+    with pytest.raises(ValueError, match="polygons geometry type must be Polygon"):
+        swn.SurfaceWaterNetwork.from_lines(valid_lines, valid_lines)
 
 
 def test_catchments_misaligned(caplog):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -579,6 +579,18 @@ def test_init_polygons():
         swn.SurfaceWaterNetwork.from_lines(valid_lines, 1.0)
 
 
+def test_catchments_misaligned(caplog):
+    caplog.clear()
+    _ = swn.SurfaceWaterNetwork.from_lines(valid_lines, valid_polygons.translate(50))
+    assert "lines and catchments don't intersect" in caplog.messages[-1]
+    caplog.clear()
+    _ = swn.SurfaceWaterNetwork.from_lines(valid_lines, valid_polygons.translate(15, 1))
+    assert "1 of 3 lines (33.3%) don't intersect their catchment" in caplog.messages[-1]
+    caplog.clear()
+    _ = swn.SurfaceWaterNetwork.from_lines(valid_lines, valid_polygons)
+    assert len(caplog.messages) == 0
+
+
 def test_catchments_property():
     # also vary previous test with 2D lines
     n = swn.SurfaceWaterNetwork.from_lines(force_2d(valid_lines))


### PR DESCRIPTION
Show a warning if lines and catchments don't intersect. This can happen for a few reasons, such as different indexes or projections between objects.

Also raise errors if the polygons geometry type is something other than Polygon and/or MultiPolygon types.