### PR TITLE
Use PEP 735 for dependency groups, rename "extra" to "optional"; CI testing with uv

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,23 +14,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Python
-        uses: actions/setup-python@v6
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: '3.10'
-          cache: 'pip'
-          cache-dependency-path: pyproject.toml
-
-      - name: Prepare Python environment
-        run: python3 -m pip install --upgrade pip
 
       - name: Install dependencies
-        run: python3 -m pip install .[doc]
+        run: uv sync --group docs
 
       - name: Build HTML
-        run: |
-          cd docs
-          make html
+        working-directory: ./docs
+        run: uv run make html
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,15 +60,15 @@ jobs:
 
       - name: Run tests with older optional packages
         if: matrix.python-version == '3.10'
-        run: |
-          uv run --group tests --extra optional \
-          -P "numpy<2.0" \
-          -P "pytest<7.0" \
-          -P "flopy<3.5" \
-          -P "geopandas<1.0" \
-          -P "matplotlib<3.7" \
-          -P "pandas<2.0" \
-          -P "shapely<2.0" \
+        run: >
+          uv run --group tests --extra optional
+          -P "numpy<2.0"
+          -P "pytest<7.0"
+          -P "flopy<3.5"
+          -P "geopandas<1.0"
+          -P "matplotlib<3.7"
+          -P "pandas<2.0"
+          -P "shapely<2.0"
           pytest -v -n2 --cov --cov-append --cov-report=xml
 
       - name: Upload coverage reports to Codecov

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,41 +28,47 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-          cache-dependency-path: pyproject.toml
 
       - name: Install Modflow executables
         uses: modflowpy/install-modflow-action@v1
 
-      - name: Install dependencies
-        run: |
-          python -m pip install pip --upgrade --disable-pip-version-check
-          pip install -e .[test]
+      - name: Install required dependencies
+        run: uv sync --group tests
 
       - name: Run tests with required packages
-        run: pytest -v --cov
+        run: uv run pytest -v
 
       - name: Install PyQt5 for macOS
         if: ${{ startsWith(matrix.os, 'macos') }}
         run: pip install PyQt5
 
-      - name: Run tests with optional packages
+      - name: Install optional packages
         run: |
-          pip install -e .[extra]
-          pytest -v -n2 --cov --cov-append
+          uv sync --extra optional --upgrade
+          # Avoid: Matplotlib is building the font cache; this may take a moment
+          uv run python -c "import matplotlib; matplotlib.get_cachedir()"
+
+      - name: Run tests with optional packages
+        run: uv run pytest -v -n2 --cov --cov-append
 
       - name: Run doctest
         if: matrix.python-version == '3.12'
-        run: |
-          pytest -v --doctest-modules src
+        run: uv run pytest -v --doctest-modules src
 
-      - name: Run tests with older flopy and other packages
+      - name: Run tests with older optional packages
         if: matrix.python-version == '3.10'
         run: |
-          pip install "flopy<3.5" "pandas<2.0" "geopandas<1.0" "shapely<2.0" "numpy<2.0"
+          uv run --group tests --extra optional \
+          -P "numpy<2.0" \
+          -P "pytest<7.0" \
+          -P "flopy<3.5" \
+          -P "geopandas<1.0" \
+          -P "matplotlib<3.7" \
+          -P "pandas<2.0" \
+          -P "shapely<2.0" \
           pytest -v -n2 --cov --cov-append
 
       - name: Upload coverage reports to Codecov

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,11 +39,7 @@ jobs:
         run: uv sync --group tests
 
       - name: Run tests with required packages
-        run: uv run pytest -v
-
-      - name: Install PyQt5 for macOS
-        if: ${{ startsWith(matrix.os, 'macos') }}
-        run: pip install PyQt5
+        run: uv run pytest -v --cov --cov-report=xml
 
       - name: Install optional packages
         run: |
@@ -51,8 +47,12 @@ jobs:
           # Avoid: Matplotlib is building the font cache; this may take a moment
           uv run python -c "import matplotlib; matplotlib.get_cachedir()"
 
+      - name: Install PyQt5 for macOS
+        if: ${{ startsWith(matrix.os, 'macos') }}
+        run: uv pip install PyQt5
+
       - name: Run tests with optional packages
-        run: uv run pytest -v -n2 --cov --cov-append
+        run: uv run pytest -v -n2 --cov --cov-append --cov-report=xml
 
       - name: Run doctest
         if: matrix.python-version == '3.12'
@@ -69,7 +69,7 @@ jobs:
           -P "matplotlib<3.7" \
           -P "pandas<2.0" \
           -P "shapely<2.0" \
-          pytest -v -n2 --cov --cov-append
+          pytest -v -n2 --cov --cov-append --cov-report=xml
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,24 +36,33 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["surface-water-network[doc,extra,test]", "pre-commit", "ruff"]
-doc = [
+optional = [
+    "flopy",
+    "matplotlib",
+    "netcdf4",
+]
+
+[dependency-groups]
+dev = [
+    {include-group = "lint"},
+    {include-group = "tests"},
+]
+lint = [
+    "ruff",
+    "pre-commit",
+]
+tests = [
+    "pytest",
+    "pytest-cov",
+    "pytest-xdist",
+]
+docs = [
     "ipython",
     "matplotlib",
     "numpydoc",
     "pydata-sphinx-theme",
     "sphinx<9",
     "sphinx-issues",
-]
-extra = [
-    "flopy >=3.3.6",
-    "matplotlib",
-    "netcdf4",
-]
-test = [
-    "pytest",
-    "pytest-cov",
-    "pytest-xdist",
 ]
 
 [project.urls]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,7 +149,7 @@ def pytest_report_header(config):
     lines.append("required packages: " + ", ".join(items))
     installed = []
     not_found = []
-    for name in extra["extra"]:
+    for name in extra["optional"]:
         if name in processed:
             continue
         processed.add(name)


### PR DESCRIPTION
There are several things going on with this PR:

- Use dependency groups (PEP 735) for development groups, instead of optional dependencies
- Rename extra "extra" to "optional", so `pip install surface-water-network[optional]` will be needed to get this
- Use uv for CI testing, since it's quick and modern
- Fix testing with different combination of new, old, required and optional packages