### PR TITLE
Compatibility fixes for pandas 1 thru 3, use StringDtype

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Read from Shapefile:
 ```python
 shp_srs = "tests/data/DN2_Coastal_strahler1z_stream_vf.shp"
 lines = geopandas.read_file(shp_srs)
-lines.set_index("nzsegment", inplace=True, verify_integrity=True)  # optional
+lines.set_index("nzsegment", inplace=True)  # optional
 ```
 
 Or, read from PostGIS:
@@ -55,7 +55,7 @@ con_url = engine.url.URL(drivername="postgresql", database="scigen")
 con = create_engine(con_url)
 sql = "SELECT * FROM wrc.rec2_riverlines_coastal"
 lines = geopandas.read_postgis(sql, con)
-lines.set_index("nzsegment", inplace=True, verify_integrity=True)  # optional
+lines.set_index("nzsegment", inplace=True)  # optional
 ```
 
 Initialise and create network:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ requires-python = ">=3.10"
 dependencies = [
     "geopandas",
     "packaging",
-    "pandas <3",
+    "pandas>=1.0",
     "pyproj",
     "rtree",
     "shapely",

--- a/src/swn/compat.py
+++ b/src/swn/compat.py
@@ -5,6 +5,7 @@ import warnings
 
 import geopandas
 import numpy as np
+import pandas as pd
 import shapely
 from packaging.version import Version
 
@@ -88,3 +89,36 @@ def sjoin_idx_names(left_df, right_df):
     else:
         right_idx_name = "index_right"
     return left_idx_name, right_idx_name
+
+
+def dataframe_str_na(df: pd.DataFrame) -> pd.DataFrame:
+    """Returns dataframe with consistent str-type columns.
+
+    A str-type column is detected if all rows are NA or if the non-NA
+    rows are str-type. These are cast with :py:meth:`pd.StringDtype` with
+    (where feasible) `na_value=pd.NA` instead of NaN.
+    """
+    df = df.copy()
+    for name, dtype in df.dtypes.items():
+        if pd.api.types.is_object_dtype(dtype):
+            isna = df[name].isna()
+            types = set(df.loc[~isna, name].map(type).unique())
+            if isna.all() or types == set({str}):
+                try:
+                    df[name] = df[name].astype(pd.StringDtype(na_value=pd.NA))
+                except TypeError:
+                    df[name] = df[name].astype(pd.StringDtype())
+                    if isna.any():
+                        df.loc[isna, name] = pd.NA
+        elif pd.api.types.is_string_dtype(dtype):
+            if hasattr(dtype, "na_value"):
+                if dtype.na_value is not pd.NA:
+                    try:
+                        # pandas 3+: change to NA missing type (probably from NaN)
+                        df[name] = df[name].astype(pd.StringDtype(na_value=pd.NA))
+                    except TypeError:
+                        df[name] = df[name].astype(pd.StringDtype())
+            elif (isna := df[name].isna()).any():
+                # pandas 2: ensure missing is NA
+                df.loc[isna, name] = pd.NA
+    return df

--- a/src/swn/file.py
+++ b/src/swn/file.py
@@ -8,9 +8,9 @@ __all__ = [
 ]
 
 import geopandas
-import numpy as np
 import pandas as pd
 
+from .compat import dataframe_str_na
 from .logger import get_logger, logging
 
 
@@ -165,9 +165,9 @@ def gdf_to_shapefile(gdf, shp_fname, **kwargs):
     for col, dtype in gdf.dtypes.items():
         if col == geom_name:
             continue
-        if dtype is bool:
+        if pd.api.types.is_bool_dtype(dtype):
             gdf[col] = gdf[col].astype(int)
-        elif np.issubdtype(dtype, np.number):
+        elif pd.api.types.is_numeric_dtype(dtype):
             pass
         else:
             is_none = gdf[col].map(lambda x: x is None).fillna(True)
@@ -251,12 +251,7 @@ def read_formatted_frame(fname):
     finally:
         if not fname_is_filelike:
             f.close()
-    # Ensure that object type (including str) use None for missing instead of NaN
-    for name, dtype in df.dtypes.items():
-        if np.issubdtype(dtype, object):
-            sel = df[name].isna()
-            df.loc[sel, name] = None
-    return df
+    return dataframe_str_na(df)
 
 
 def write_formatted_frame(df, fname, index=True, comment_header=True):
@@ -357,12 +352,20 @@ def write_formatted_frame(df, fname, index=True, comment_header=True):
     formatters = {}
     # scan for str type columns
     for icol, name in enumerate(df.columns):
-        # add single quotes around items with space chars
-        try:
-            sel = df[name].str.contains(" ").astype(bool)
+        na = df[name].isna()
+        if na.all() or not pd.api.types.is_string_dtype(df[name].dtype):
+            continue
+        try:  # skip over non-string columns, including object types
+            df[name].str.contains(" ")
         except AttributeError:
             continue
-        na = df[name].isna()
+        # add single quotes around items with space chars
+        sel = na.copy()
+        sel[:] = False
+        try:
+            sel.loc[~na] = df.loc[~na, name].str.contains(" ").astype(bool)
+        except AttributeError:
+            continue
         if sel.any():
             df.loc[sel, name] = df.loc[sel, name].map(lambda x: f"'{x}'")
             df.loc[~sel, name] = df.loc[~sel, name].map(lambda x: f" {x} ")

--- a/src/swn/modflow/_base.py
+++ b/src/swn/modflow/_base.py
@@ -599,7 +599,7 @@ class SwnModflowBase:
                     matches.reverse()
                 reach_c["d1"] = reach_c["pt"].apply(lambda p: p.distance(matches[0][1]))
                 reach_c["d2"] = reach_c["pt"].apply(lambda p: p.distance(matches[1][1]))
-                reach_c["dm"] = reach_c[["d1", "d2"]].min(1)
+                reach_c["dm"] = reach_c[["d1", "d2"]].min(axis=1)
                 # try a simple split where distances switch
                 ds = reach_c["d1"] < reach_c["d2"]
                 cidx = ds[ds].index[-1]
@@ -683,7 +683,7 @@ class SwnModflowBase:
                         matches.reverse()
                     rem_c["d1"] = rem_c["pt"].apply(lambda p: p.distance(matches[0][2]))
                     rem_c["d2"] = rem_c["pt"].apply(lambda p: p.distance(matches[1][2]))
-                    rem_c["dm"] = rem_c[["d1", "d2"]].min(1)
+                    rem_c["dm"] = rem_c[["d1", "d2"]].min(axis=1)
                     mdist = rem_c["dm"].max()
                     if mdist > threshold:
                         obj.logger.debug(
@@ -825,7 +825,7 @@ class SwnModflowBase:
                 if domain_action == "modify" and domain[i, j] == 0:
                     num_domain_modified += 1
                     domain[i, j] = 1
-                    obj.grid_cells[obj.domain_label].at[i, j] = 1
+                    obj.grid_cells.at[(i, j), obj.domain_label] = 1
 
         if domain_action == "modify":
             if num_domain_modified:
@@ -896,7 +896,13 @@ class SwnModflowBase:
         if has_diversions:
             diversions = swn.diversions.copy()
             reaches["diversion"] = False
-            reaches["divid"] = diversions.index.dtype.type()
+            if pd.api.types.is_integer_dtype(diversions.index.dtype):
+                divid_na = 0
+            elif pd.api.types.is_float_dtype(diversions.index.dtype):
+                divid_na = np.nan
+            else:
+                divid_na = pd.NA
+            reaches["divid"] = divid_na
             # Mark diversions that are not used / outside model
             diversions["in_model"] = True
             outside_model = []
@@ -1094,7 +1100,7 @@ class SwnModflowBase:
                 method = "continuous"
             else:
                 value = self._swn.segments_series(value)
-                if np.issubdtype(value, np.floating):
+                if pd.api.types.is_float_dtype(value.dtype):
                     method = "continuous"
                 else:
                     method = "constant"
@@ -1102,7 +1108,7 @@ class SwnModflowBase:
                 "set_reach_data_from_segments: choosing method=%r", method
             )
         if method == "continuous":
-            if not np.issubdtype(value.dtype, np.floating):
+            if not pd.api.types.is_float_dtype(value.dtype):
                 value = value.astype(float)
         segdat = self._swn.pair_segments_frame(value, value_out, method=method)
         c1, c2 = segdat.columns

--- a/src/swn/modflow/_misc.py
+++ b/src/swn/modflow/_misc.py
@@ -229,9 +229,7 @@ def invert_series(series):
     assert series_name, series_name
     index_name = series.index.name
     assert index_name, index_name
-    return series.reset_index().set_index(series_name, verify_integrity=True)[
-        index_name
-    ]
+    return series.reset_index().set_index(series_name)[index_name]
 
 
 def tile_series_as_frame(series, index):

--- a/src/swn/modflow/_swnmf6.py
+++ b/src/swn/modflow/_swnmf6.py
@@ -12,7 +12,7 @@ import numpy as np
 import pandas as pd
 from shapely import wkt
 
-from ..compat import ignore_shapely_warnings_for_object_array
+from ..compat import dataframe_str_na, ignore_shapely_warnings_for_object_array
 from ..file import write_formatted_frame
 from ..util import abbr_str
 from ._base import SwnModflowBase
@@ -369,6 +369,7 @@ class SwnMf6(SwnModflowBase):
         if missing:
             missing_list = ", ".join(missing)
             raise KeyError(f"missing {len(missing)} {what}: {missing_list}")
+        dat = dataframe_str_na(dat)
         return dat.loc[:, defcols_names]
 
     def packagedata_frame(self, style: str, auxiliary: list = [], boundname=None):
@@ -688,6 +689,7 @@ class SwnMf6(SwnModflowBase):
             dat[[self.reach_index_name, "idv", "iconr"]] -= 1
         else:
             raise ValueError("'style' must be either 'native' or 'flopy'")
+        dat = dataframe_str_na(dat)
         return dat[defcols_names]
 
     def write_diversions(self, fname: str):

--- a/src/swn/modflow/_swnmodflow.py
+++ b/src/swn/modflow/_swnmodflow.py
@@ -876,7 +876,6 @@ class SwnModflow(SwnModflowBase):
                 ),
             ],
             axis=1,
-            copy=False,
         )
         for name, series in more_segment_columns.items():
             self.segments[name] = series
@@ -1742,11 +1741,7 @@ class SwnModflow(SwnModflowBase):
             ]
         else:
             segnum_iseg_df = self.reaches[["segnum", "iseg"]]
-        segnum_iseg = (
-            segnum_iseg_df.drop_duplicates()
-            .set_index("segnum", verify_integrity=True)
-            .iseg
-        )
+        segnum_iseg = segnum_iseg_df.drop_duplicates().set_index("segnum").iseg
 
         to_reachids_d = {}
         for segnum, iseg in segnum_iseg.items():

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,17 @@
+"""Common code for testing."""
+
+import re
+from pathlib import Path
+
+import pandas as pd
+
+try:
+    import matplotlib
+    import matplotlib.pyplot as plt
+except ImportError:
+    matplotlib = None
+    plt = None
+
+datadir = Path("tests") / "data"
+
+PANDAS_VERSION_TUPLE = tuple(int(x) for x in re.findall(r"\d+", pd.__version__))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,34 +1,23 @@
-"""Common code for testing."""
+"""Pytest fixtures and features."""
 
 import re
 import sys
 from importlib import metadata
-from pathlib import Path
 
 import geopandas
 import pandas as pd
 import pytest
 from shapely import wkt
 
-try:
-    import matplotlib
-    import matplotlib.pyplot as plt
-except ImportError:
-    matplotlib = False
-    plt = None
-
-if matplotlib and sys.platform == "darwin":
-    matplotlib.use("qt5agg")
-
-
 # Import this local package for tests
 #  sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import swn
 from swn.compat import ignore_shapely_warnings_for_object_array
 
-PANDAS_VESRSION_TUPLE = tuple(int(x) for x in re.findall(r"\d+", pd.__version__))
+from .common import datadir, matplotlib
 
-datadir = Path("tests") / "data"
+if matplotlib and sys.platform == "darwin":
+    matplotlib.use("qt5agg")
 
 
 # https://commons.wikimedia.org/wiki/File:Flussordnung_(Strahler).svg
@@ -116,7 +105,7 @@ def coastal_flow_ts():
 
 @pytest.fixture(scope="module")
 def coastal_flow_m(coastal_flow_ts):
-    coastal_flow_m = pd.DataFrame(coastal_flow_ts.mean(0)).T
+    coastal_flow_m = pd.DataFrame(coastal_flow_ts.mean(axis=0)).T
     # coastal_flow_m.index = pd.DatetimeIndex(["2000-01-01"])
     return coastal_flow_m
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -13,7 +13,7 @@ import swn
 from swn.compat import GEOPANDAS_GE_100, ignore_shapely_warnings_for_object_array
 from swn.spatial import force_2d, round_coords
 
-from .conftest import matplotlib, plt
+from .common import matplotlib, plt
 
 # a few static objects (not fixtures)
 

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,6 +1,8 @@
 """Test compat module."""
 
 import geopandas
+import numpy as np
+import pandas as pd
 from shapely.geometry import Point
 
 from swn import compat
@@ -48,3 +50,75 @@ def test_sjoin_idx_names():
     assert sj.index.name == left_idx_name
     assert left_idx_name not in sj.columns
     assert right_idx_name in sj.columns
+
+
+def test_dataframe_str_na_zero_na():
+    # no missing values, just make sure correct str-type (for pandas 3+)
+    zero_na = pd.DataFrame({"a": ["one", "two"], "b": [1, 2]})
+    zero_na_check = zero_na.copy()
+    try:
+        zero_na_check["a"] = zero_na_check["a"].astype(pd.StringDtype(na_value=pd.NA))
+    except TypeError:
+        zero_na_check["a"] = zero_na_check["a"].astype(pd.StringDtype())
+    pd.testing.assert_frame_equal(compat.dataframe_str_na(zero_na), zero_na_check)
+    # repeat with object dtype
+    zero_na["a"] = zero_na["a"].astype(object)
+    pd.testing.assert_frame_equal(compat.dataframe_str_na(zero_na), zero_na_check)
+
+
+def test_dataframe_str_na_one_none():
+    # only one missing value, originally supplied as None
+    one_none = pd.DataFrame({"a": ["one", None], "b": [np.nan, 2.0]})
+    one_none_check = one_none.copy()
+    try:
+        one_none_check["a"] = one_none_check["a"].astype(pd.StringDtype(na_value=pd.NA))
+    except TypeError:
+        one_none_check["a"] = one_none_check["a"].astype(pd.StringDtype())
+        one_none_check.loc[1, "a"] = pd.NA
+    pd.testing.assert_frame_equal(compat.dataframe_str_na(one_none), one_none_check)
+    # repeat with object dtype
+    one_none["a"] = one_none["a"].astype(object)
+    pd.testing.assert_frame_equal(compat.dataframe_str_na(one_none), one_none_check)
+
+
+def test_dataframe_str_na_one_na():
+    # only one missing value, originally supplied as NA
+    one_na = pd.DataFrame({"a": ["one", pd.NA], "b": [np.nan, 2]})
+    one_na_check = pd.DataFrame({"a": ["one", pd.NA], "b": [np.nan, 2]})
+    try:
+        one_na_check["a"] = one_na_check["a"].astype(pd.StringDtype(na_value=pd.NA))
+    except TypeError:
+        one_na_check["a"] = one_na_check["a"].astype(pd.StringDtype())
+    pd.testing.assert_frame_equal(compat.dataframe_str_na(one_na), one_na_check)
+    # repeat with object dtype
+    one_na["a"] = one_na["a"].astype(object)
+    pd.testing.assert_frame_equal(compat.dataframe_str_na(one_na), one_na_check)
+
+
+def test_dataframe_str_na_all_na():
+    # all missing values supplied as NA stay as NA
+    all_na = pd.DataFrame({"a": [pd.NA, pd.NA], "b": [1, pd.NA]})
+    all_na_check = all_na.copy()
+    try:
+        all_na_check["a"] = all_na_check["a"].astype(pd.StringDtype(na_value=pd.NA))
+    except TypeError:
+        all_na_check["a"] = all_na_check["a"].astype(pd.StringDtype())
+    pd.testing.assert_frame_equal(compat.dataframe_str_na(all_na), all_na_check)
+    # repeat with object dtype
+    all_na["a"] = all_na["a"].astype(object)
+    pd.testing.assert_frame_equal(compat.dataframe_str_na(all_na), all_na_check)
+
+
+def test_dataframe_str_na_all_none():
+    # all missing values supplied as None change to NA
+    all_none = pd.DataFrame({"a": [None, None], "b": [1, None]})
+    all_none_check = pd.DataFrame({"a": [pd.NA, pd.NA], "b": [1.0, np.nan]})
+    all_none_check["a"] = pd.NA
+    try:
+        all_none_check["a"] = all_none_check["a"].astype(pd.StringDtype(na_value=pd.NA))
+    except TypeError:
+        all_none_check["a"] = all_none_check["a"].astype(pd.StringDtype())
+    pd.testing.assert_frame_equal(compat.dataframe_str_na(all_none), all_none_check)
+    # repeat with object dtype
+    all_none["a"] = all_none["a"].astype(object)
+    pd.testing.assert_frame_equal(compat.dataframe_str_na(all_none), all_none_check)

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -6,7 +6,7 @@ import pytest
 
 import swn
 
-from .conftest import matplotlib, plt
+from .common import matplotlib, plt
 
 
 def test_init(coastal_swn, coastal_lines_gdf):

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -9,7 +9,7 @@ from shapely.geometry import Point
 
 import swn
 
-from .conftest import PANDAS_VESRSION_TUPLE, datadir
+from .common import PANDAS_VERSION_TUPLE, datadir
 
 # same valid network used in test_basic
 n3d_lines = geopandas.GeoSeries.from_wkt(
@@ -42,7 +42,7 @@ def test_topnet2ts(coastal_flow_ts):
     assert list(pd.unique(flow.dtypes)) == [np.float32]
     # remove time and truncate to closest day
     try:
-        flow.index = flow.index.floor("d")
+        flow.index = flow.index.floor("D")
     except AttributeError:
         # older pandas
         flow.index = pd.to_datetime(flow.index.map(lambda x: x.strftime("%Y-%m-%d")))
@@ -65,10 +65,10 @@ def test_gdf_to_shapefile(tmp_path, coastal_swn):
     assert "from_segnums" in gdf.columns
     assert "from_seg" not in gdf.columns
     shp = geopandas.read_file(fname)
-    assert np.issubdtype(shp["nzsegment"].dtype, np.integer)
-    assert np.issubdtype(shp["from_seg"].dtype, np.object_)
-    assert np.issubdtype(shp["to_seg"].dtype, np.integer)
-    assert np.issubdtype(shp["upstr_len"].dtype, np.floating)
+    assert pd.api.types.is_integer_dtype(shp["nzsegment"])
+    assert pd.api.types.is_string_dtype(shp["from_seg"])
+    assert pd.api.types.is_integer_dtype(shp["to_seg"])
+    assert pd.api.types.is_float_dtype(shp["upstr_len"])
     shp.set_index("nzsegment", inplace=True)
     assert list(shp.columns) == [
         "to_seg",
@@ -120,11 +120,15 @@ def test_read_write_formatted_frame(tmp_path):
         {
             "value1": [-1e10, -1e-10, 0, 1e-10, 1, 1000],
             "value2": [1, 10, 100, 1000, 10000, 100000],
-            "value3": ["first one", "two", "three", None, "five", "six"],
+            "value3": ["first one", "two", "three", pd.NA, "five", "six"],
         },
         index=[1, 12, 33, 40, 450, 6267],
     )
     df1.index.name = "rno"
+    try:
+        df1["value3"] = df1["value3"].astype(pd.StringDtype(na_value=pd.NA))
+    except TypeError:
+        df1["value3"] = df1["value3"].astype(pd.StringDtype())
 
     # test default write method
     fname = tmp_path / "file.dat"
@@ -165,7 +169,7 @@ def test_read_write_formatted_frame(tmp_path):
     lines = fname.read_text().splitlines()
     assert len(lines) == 7
     # check first line, space between object columns differ between versions!
-    if (2, 0, 0) <= PANDAS_VESRSION_TUPLE <= (2, 0, 2):
+    if (2, 0, 0) <= PANDAS_VERSION_TUPLE <= (2, 0, 2):
         expected = "#      value1  value2  value3"
     else:
         expected = "#      value1  value2 value3"

--- a/tests/test_modflow.py
+++ b/tests/test_modflow.py
@@ -14,10 +14,8 @@ import swn
 from swn.file import gdf_to_shapefile
 from swn.spatial import force_2d, interp_2d_to_3d
 
-if __name__ != "__main__":
-    from .conftest import datadir, matplotlib, plt
-else:
-    from conftest import datadir, matplotlib, plt
+from .common import datadir, matplotlib, plt
+
 try:
     import flopy
 except ImportError:
@@ -367,8 +365,10 @@ def test_model_property():
     # Success!
     nm.model = m
 
+    # nm.time_index can be either datetime64[us] vs datetime64[ns]
+    assert pd.api.types.is_datetime64_any_dtype(nm.time_index.dtype)
     pd.testing.assert_index_equal(
-        nm.time_index, pd.DatetimeIndex(["2001-02-03"], dtype="datetime64[ns]")
+        nm.time_index, pd.DatetimeIndex(["2001-02-03"], dtype=nm.time_index.dtype)
     )
     assert nm.grid_cells.shape == (6, 2)
 

--- a/tests/test_modflow6.py
+++ b/tests/test_modflow6.py
@@ -14,7 +14,7 @@ import swn
 from swn.file import gdf_to_shapefile
 from swn.spatial import force_2d, interp_2d_to_3d
 
-from .conftest import datadir, matplotlib, plt
+from .common import datadir, matplotlib, plt
 
 try:
     import flopy
@@ -350,16 +350,24 @@ def test_n3d_defaults(tmp_path, has_diversions):
         assert nm.diversions_frame("native").shape == (0, 4)
         assert nm.flopy_diversions() == []
     else:
+        expected_frame = pd.DataFrame(
+            {
+                ridxname: [3, 5, 6, 6],
+                "idv": [1, 1, 1, 2],
+                "iconr": [8, 9, 10, 11],
+                "cprior": "upto",
+            }
+        )
+        try:
+            expected_frame["cprior"] = expected_frame["cprior"].astype(
+                pd.StringDtype(na_value=pd.NA)
+            )
+        except TypeError:
+            expected_frame["cprior"] = expected_frame["cprior"].astype(pd.StringDtype())
+
         pd.testing.assert_frame_equal(
             nm.diversions_frame("native"),
-            pd.DataFrame(
-                {
-                    ridxname: [3, 5, 6, 6],
-                    "idv": [1, 1, 1, 2],
-                    "iconr": [8, 9, 10, 11],
-                    "cprior": "upto",
-                }
-            ),
+            expected_frame,
         )
         expected = [
             [2, 0, 7, "upto"],
@@ -523,8 +531,10 @@ def test_model_property():
     # Success!
     nm.model = gwf
 
+    # nm.time_index can be either datetime64[us] vs datetime64[ns]
+    assert pd.api.types.is_datetime64_any_dtype(nm.time_index.dtype)
     pd.testing.assert_index_equal(
-        nm.time_index, pd.DatetimeIndex(["2001-02-03"], dtype="datetime64[ns]")
+        nm.time_index, pd.DatetimeIndex(["2001-02-03"], dtype=nm.time_index.dtype)
     )
     assert nm.grid_cells.shape == (6, 2)
 
@@ -749,8 +759,8 @@ def test_packagedata(tmp_path):
     # With auxiliary and boundname
     gwf.remove_package("sfr")
     nm.reaches["boundname"] = nm.reaches["segnum"].astype(str)
-    nm.reaches.boundname.at[1] = "another reach"
-    nm.reaches.boundname.at[2] = "longname" * 6
+    nm.reaches.at[1, "boundname"] = "another reach"
+    nm.reaches.at[2, "boundname"] = "longname" * 6
     nm.reaches["var1"] = np.arange(len(nm.reaches), dtype=float) * 12.0
     nm.set_sfr_obj(auxiliary=["var1"])
     assert list(gwf.sfr.packagedata.array.dtype.names) == [
@@ -1211,16 +1221,25 @@ def test_n3d_defaults_with_div_on_outlet(tmp_path):
     ]
     assert nm.flopy_connectiondata() == expected
     nm.write_diversions(tmp_path / "diversions.dat")
+
+    expected_frame = pd.DataFrame(
+        {
+            ridxname: [3, 5, 7, 7],
+            "idv": [1, 1, 1, 2],
+            "iconr": [8, 9, 10, 11],
+            "cprior": "upto",
+        }
+    )
+    try:
+        expected_frame["cprior"] = expected_frame["cprior"].astype(
+            pd.StringDtype(na_value=pd.NA)
+        )
+    except TypeError:
+        expected_frame["cprior"] = expected_frame["cprior"].astype(pd.StringDtype())
+
     pd.testing.assert_frame_equal(
         nm.diversions_frame("native"),
-        pd.DataFrame(
-            {
-                ridxname: [3, 5, 7, 7],
-                "idv": [1, 1, 1, 2],
-                "iconr": [8, 9, 10, 11],
-                "cprior": "upto",
-            }
-        ),
+        expected_frame,
     )
     expected = [
         [2, 0, 7, "upto"],
@@ -1365,14 +1384,11 @@ def test_diversions(tmp_path):
     df = nm.packagedata_frame("native")
     for col in "kij":
         df[col] = df[col].astype(np.int64)
-    pd.testing.assert_frame_equal(
-        df,
-        swn.file.read_formatted_frame(tmp_path / "packagedata.dat").set_index(ridxname),
-    )
-    pd.testing.assert_frame_equal(
-        nm.diversions_frame("native").reset_index(drop=True),
-        swn.file.read_formatted_frame(tmp_path / "diversions.dat"),
-    )
+    r = swn.file.read_formatted_frame(tmp_path / "packagedata.dat").set_index(ridxname)
+    pd.testing.assert_frame_equal(df, r)
+    df = nm.diversions_frame("native").reset_index(drop=True)
+    r = swn.file.read_formatted_frame(tmp_path / "diversions.dat")
+    pd.testing.assert_frame_equal(df, r)
 
     # Route some flow from headwater reaches
     perioddata = [
@@ -1626,6 +1642,11 @@ def test_package_period_frame():
             [(1, ridx + 1) for ridx in range(7)], names=["per", ridxname]
         ),
     )
+    for col in list("kij"):
+        try:
+            exp_native[col] = exp_native[col].astype(pd.StringDtype(na_value=pd.NA))
+        except TypeError:
+            exp_native[col] = exp_native[col].astype(pd.StringDtype())
     exp_flopy = pd.DataFrame(
         {
             "cellid": [
@@ -1667,13 +1688,30 @@ def test_package_period_frame():
     )
 
     # with boundname
+    boundname_l = ["1", "1", "1", "2", "2", "0", "0"]
+    try:
+        boundname_series = pd.Series(
+            boundname_l, index=exp_native.index, dtype=pd.StringDtype(na_value=pd.NA)
+        )
+    except TypeError:
+        boundname_series = pd.Series(
+            boundname_l, index=exp_native.index, dtype=pd.StringDtype()
+        )
     pd.testing.assert_frame_equal(
         nm.package_period_frame("drn", "native"),
-        exp_native.assign(boundname=["1", "1", "1", "2", "2", "0", "0"]),
+        exp_native.assign(boundname=boundname_series),
     )
+    try:
+        boundname_series = pd.Series(
+            boundname_l, index=exp_flopy.index, dtype=pd.StringDtype(na_value=pd.NA)
+        )
+    except TypeError:
+        boundname_series = pd.Series(
+            boundname_l, index=exp_flopy.index, dtype=pd.StringDtype()
+        )
     pd.testing.assert_frame_equal(
         nm.package_period_frame("drn", "flopy"),
-        exp_flopy.assign(boundname=["1", "1", "1", "2", "2", "0", "0"]),
+        exp_flopy.assign(boundname=boundname_series),
     )
 
     # with boundname and auxiliary

--- a/tests/test_modflow_base.py
+++ b/tests/test_modflow_base.py
@@ -21,7 +21,7 @@ import swn
 import swn.modflow
 from swn.spatial import force_2d, interp_2d_to_3d
 
-from .conftest import datadir, matplotlib, plt
+from .common import datadir, matplotlib, plt
 
 try:
     import flopy
@@ -1222,7 +1222,7 @@ def test_get_segments_inflow():
         pd.DataFrame(dtype=float, index=nm.time_index),
     )
 
-    nm.segments.from_segnums.at[1] = {4}
+    nm.segments.at[1, "from_segnums"] = {4}
 
     pd.testing.assert_series_equal(
         nm._get_segments_inflow({4: 1.1}), pd.Series({1: 1.1})
@@ -1242,7 +1242,7 @@ def test_get_segments_inflow():
         pd.DataFrame({1: [1.1]}, index=nm.time_index),
     )
 
-    nm.segments.from_segnums.at[1] = {4, 5}
+    nm.segments.at[1, "from_segnums"] = {4, 5}
 
     pd.testing.assert_series_equal(
         nm._get_segments_inflow({5: 2.2, 4: 1.1}), pd.Series({1: 3.3})
@@ -1272,7 +1272,7 @@ def test_get_segments_inflow():
         pd.DataFrame(dtype=float, index=nm.time_index),
     )
 
-    nm.segments.from_segnums.at[1] = {4}
+    nm.segments.at[1, "from_segnums"] = {4}
 
     pd.testing.assert_series_equal(
         nm._get_segments_inflow({4: 1.1}), pd.Series({1: 1.1})
@@ -1292,7 +1292,7 @@ def test_get_segments_inflow():
         pd.DataFrame({1: [1.1, 1.2]}, index=nm.time_index),
     )
 
-    nm.segments.from_segnums.at[1] = {4, 5}
+    nm.segments.at[1, "from_segnums"] = {4, 5}
 
     pd.testing.assert_series_equal(
         nm._get_segments_inflow({5: 2.2, 4: 1.1}), pd.Series({1: 3.3})

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -50,10 +50,10 @@ def test_is_location_frame():
         is_location_frame(gdf.drop(columns="segnum"))
     with pytest.raises(ValueError, match="must have 'seg_ndist' column"):
         is_location_frame(gdf.drop(columns="seg_ndist"))
-    gdf.geometry.at[2] = gdf.geometry.at[1].centroid
+    gdf.at[2, "geometry"] = gdf.loc[1, "geometry"].centroid
     with pytest.raises(ValueError, match="geometry expected to be LineString"):
         is_location_frame(gdf, True)
-    gdf.geometry.at[2] = LineString([(0, 0), (1, 1), (3, 3)])
+    gdf.at[2, "geometry"] = LineString([(0, 0), (1, 1), (3, 3)])
     with pytest.raises(
         ValueError, match="geometry expected to only have two coordinate"
     ):


### PR DESCRIPTION
Aim to get better compatibility with pandas versions 1 thru 3.

Use more `pd.StringDtype` (and `StringDtype(na_value=pd.NA)`, where possible) instead of `str` type, which is an object dtype with pre 3.0 versions.